### PR TITLE
Update docs for Paraglob.

### DIFF
--- a/components/index.rst
+++ b/components/index.rst
@@ -26,3 +26,6 @@ respective GitHub repositories or documentation:
 * `Package Manager <https://github.com/zeek/package-manager>`__
   - A package manager for Zeek
   - `(Docs) <https://docs.zeek.org/projects/package-manager>`__
+* `Paraglob <https://github.com/zeek/paraglob>`__
+  - A pattern matching data structure for Zeek.
+  - `(Docs) <https://github.com/zeek/paraglob/blob/master/README.md>`__

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -957,6 +957,24 @@ Here is a more detailed description of each type:
     necessary to have a handle as a way of identifying it and
     distinguishing it from other such resources.
 
+    The scripting layer implementations of these types are found primarily in
+    :doc:`/scripts/base/bif/bro.bif.zeek` and a more granular look at them
+    can be found in ``src/OpaqueVal.h`` inside the Zeek repo. Opaque types serve
+    as an excellent way to integrate functionality into Zeek without needing to
+    add a new type to the scripting language.
+
+    Another example of an opaque type is paraglob, a data structure for fast
+    pattern matching which can be used as follows:
+
+    .. sourcecode:: bro
+
+      local v = vector("*", "d?g", "*og", "d?", "d[!wl]g");
+      local p = paraglob_init(v);
+      print paraglob_get(p1, "dog");
+      # out: [*, *og, d?g, d[!wl]g]
+
+    For more documentation on paraglob see :doc:`/components/index`.
+
 .. zeek:type:: any
 
     Used to bypass strong typing.  For example, a function can take an
@@ -964,11 +982,12 @@ Here is a more detailed description of each type:
     The only operation allowed on a variable of type ``any`` is assignment.
 
     Note that users aren't expected to use this type.  It's provided mainly
-    for use by some built-in functions and scripts included with Bro.
+    for use by some built-in functions and scripts included with Bro. For
+    example, passing a vector into a ``.bif`` function is best accomplished by
+    taking :zeek:type:`any` as an argument and casting it to a vector.
 
 .. zeek:type:: void
 
     An internal Bro type (i.e., "void" is not a reserved keyword in the Bro
     scripting language) representing the absence of a return type for a
     function.
-

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -947,6 +947,7 @@ Here is a more detailed description of each type:
     .. sourcecode:: bro
 
         local handle = md5_hash_init();
+        # Explicitly -> local handle : opaque of md5 = ...
         md5_hash_update(handle, "test");
         md5_hash_update(handle, "testing");
         print md5_hash_finish(handle);
@@ -959,21 +960,37 @@ Here is a more detailed description of each type:
 
     The scripting layer implementations of these types are found primarily in
     :doc:`/scripts/base/bif/bro.bif.zeek` and a more granular look at them
-    can be found in ``src/OpaqueVal.h`` inside the Zeek repo. Opaque types serve
-    as an excellent way to integrate functionality into Zeek without needing to
-    add a new type to the scripting language.
+    can be found in ``src/OpaqueVal.h/cc`` inside the Zeek repo. Opaque types
+    are an good way to integrate functionality into Zeek without needing to
+    add an entire new type to the scripting language.
 
-    Another example of an opaque type is paraglob, a data structure for fast
-    pattern matching which can be used as follows:
+    .. zeek:type:: paraglob
 
-    .. sourcecode:: bro
+      An opqaue type for creating and using paraglob data structures inside of
+      Zeek. A paraglob is a data structure for fast string matching against a
+      large set of glob style patterns. It can be loaded with a vector of
+      patterns, and then queried with input strings. For a query it returns all
+      of the patterns that it contains matching that input string.
 
-      local v = vector("*", "d?g", "*og", "d?", "d[!wl]g");
-      local p = paraglob_init(v);
-      print paraglob_get(p1, "dog");
-      # out: [*, *og, d?g, d[!wl]g]
+      Paraglobs offer significant performance advantages over making a pass over
+      a vector of patterns and checking each one. Note though that initializing a
+      paraglob can take some time for very large pattern sets (1,000,000+
+      patterns) and care should be taken to only initialize one with a large
+      pattern set when there is time for the paraglob to compile. Subsequent get
+      operations run very quickly though, even for very large pattern sets.
 
-    For more documentation on paraglob see :doc:`/components/index`.
+      .. sourcecode:: bro
+
+        local v = vector("*", "d?g", "*og", "d?", "d[!wl]g");
+        local p : opaque of paraglob = paraglob_init(v);
+        print paraglob_get(p1, "dog");
+        # out: [*, *og, d?g, d[!wl]g]
+
+      For more documentation on paraglob see :doc:`/components/index`.
+
+    .. zeek:see:: md5_hash_init sha1_hash_init sha256_hash_init
+                  hll_cardinality_add bloomfilter_basic_init
+
 
 .. zeek:type:: any
 

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -969,8 +969,9 @@ Here is a more detailed description of each type:
       An opqaue type for creating and using paraglob data structures inside of
       Zeek. A paraglob is a data structure for fast string matching against a
       large set of glob style patterns. It can be loaded with a vector of
-      patterns, and then queried with input strings. For a query it returns all
-      of the patterns that it contains matching that input string.
+      patterns, and then queried with input strings. Note that these patterns are
+      just strings, and not the pattern type built in to Zeek. For a query it 
+      returns all of the patterns that it contains matching that input string.
 
       Paraglobs offer significant performance advantages over making a pass over
       a vector of patterns and checking each one. Note though that initializing a

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -961,7 +961,7 @@ Here is a more detailed description of each type:
     The scripting layer implementations of these types are found primarily in
     :doc:`/scripts/base/bif/bro.bif.zeek` and a more granular look at them
     can be found in ``src/OpaqueVal.h/cc`` inside the Zeek repo. Opaque types
-    are an good way to integrate functionality into Zeek without needing to
+    are a good way to integrate functionality into Zeek without needing to
     add an entire new type to the scripting language.
 
     .. zeek:type:: paraglob

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -983,7 +983,7 @@ Here is a more detailed description of each type:
 
         local v = vector("*", "d?g", "*og", "d?", "d[!wl]g");
         local p : opaque of paraglob = paraglob_init(v);
-        print paraglob_get(p1, "dog");
+        print paraglob_match(p1, "dog");
         # out: [*, *og, d?g, d[!wl]g]
 
       For more documentation on paraglob see :doc:`/components/index`.


### PR DESCRIPTION
See: https://github.com/zeek/zeek/pull/371

Updates documentation to include new paraglob submodule and adds some additional information about opaque types to give people working on them in the future a better starting point.

The actual syntax surrounding paraglob should be finalized and it should be merged into Zeek before this is merged :)