### PR TITLE
Improved grammar in &broker_store and &broker_allow_complex_type and added missing semicolon

### DIFF
--- a/examples/scripting/index.rst
+++ b/examples/scripting/index.rst
@@ -179,9 +179,9 @@ type of notice we will generate with the Notice framework.  Zeek
 allows for re-definable constants, which at first, might seem
 counter-intuitive.  We'll get more in-depth with constants in a later
 chapter, for now, think of them as variables that can only be altered
-before Zeek starts running.  The notice type listed allows for the use
-of the :zeek:id:`NOTICE` function to generate notices of type
-``TeamCymruMalwareHashRegistry::Match`` as done in the next section.  Notices
+before Zeek starts running.  By extending the Notice::Type as shown, this
+allows for the NOTICE function to generate notices with a $note field set
+as TeamCymruMalwareHashRegistry::Match.  Notices
 allow Zeek to generate some kind of extra notification beyond its
 default log types.  Often times, this extra notification comes in the
 form of an email generated and sent to a preconfigured address, but can

--- a/examples/scripting/index.rst
+++ b/examples/scripting/index.rst
@@ -259,8 +259,8 @@ in the local variable ``MHR_result``.  Effectively, processing for
 this event continues and upon receipt of the values returned by
 :zeek:id:`lookup_hostname_txt`, the ``when`` block is executed.  The
 ``when`` block splits the string returned into a portion for the date on which
-the malware was first detected and the detection rate by splitting on an text space
-and storing the values returned in a local table variable.
+the malware was first detected, and the detection rate, by splitting the text
+on space and storing the values returned in a local table variable.
 In the ``do_mhr_lookup`` function, if the table
 returned by ``split1`` has two entries, indicating a successful split, we
 store the detection
@@ -962,7 +962,7 @@ use of the :zeek:id:`connection_established` event handler to generate text
 every time a SYN/ACK packet is seen responding to a SYN packet as part
 of a TCP handshake.  The text generated, is in the format of a
 timestamp and an indication of who the originator and responder were.
-We use the ``strftime`` format string of ``%Y%m%d %H:%M:%S`` to
+We use the ``strftime`` format string of ``%Y-%m-%d %H:%M:%S`` to
 produce a common date time formatted time stamp.
 
 .. literalinclude:: data_type_time.zeek
@@ -990,14 +990,14 @@ established connections.
 interval
 ~~~~~~~~
 
-The interval data type is another area in Zeek where rational
+The ``interval`` data type is another area in Zeek where rational
 application of abstraction makes perfect sense.  As a data type, the
-interval represents a relative time as denoted by a numeric constant
+``interval`` represents a relative time as denoted by a numeric constant
 followed by a unit of time.  For example, 2.2 seconds would be
 ``2.2sec`` and thirty-one days would be represented by ``31days``.
 Zeek supports ``usec``, ``msec``, ``sec``, ``min``, ``hr``, or ``day`` which represent
 microseconds, milliseconds, seconds, minutes, hours, and days
-respectively.  In fact, the interval data type allows for a surprising
+respectively.  In fact, the ``interval`` data type allows for a surprising
 amount of variation in its definitions.  There can be a space between
 the numeric constant or they can be crammed together like a temporal
 portmanteau.  The time unit can be either singular or plural.  All of
@@ -1010,7 +1010,7 @@ Intervals can even be negated, allowing for ``- 10mins`` to represent
 Intervals in Zeek can have mathematical operations performed against
 them allowing the user to perform addition, subtraction,
 multiplication, division, and comparison operations. As well, Zeek
-returns an interval when comparing two ``time`` values using the ``-``
+returns an ``interval`` when differencing two ``time`` values using the ``-``
 operator.  The script below amends the script started in the section
 above to include a time delta value printed along with the connection
 establishment report.
@@ -1021,8 +1021,8 @@ establishment report.
    :linenos:
    :tab-width: 4
 
-This time, when we execute the script we see an additional line in the
-output to display the time delta since the last fully established
+When we re-execute the script we see an additional line in the
+output, displaying the time delta since the last fully established
 connection.
 
 .. code-block:: console

--- a/script-reference/attributes.rst
+++ b/script-reference/attributes.rst
@@ -386,12 +386,11 @@ example, to bind a table to a memory-backed Broker store, use:
 &broker_store
 -------------
 
-This attribute is similar to :zeek:attr:`&backend` and allows to bind a zeek
-table to a Broker store. In difference to :zeek:attr:`&backend` this attribute
-allows you to specify the name of a Broker store you want to bind to without
-creating it.
+This attribute is similar to :zeek:attr:`&backend` in allowing a zeek table to 
+bind to a Broker store. It differs from :zeek:attr:`&backend` as this attribute
+allows you to specify the Broker store you want to bind, without creating it.
 
-You can use this is you want to bind a table to a Broker store with special options.
+Use this if you want to bind a table to a Broker store with special options.
 
 Example:
 
@@ -425,10 +424,9 @@ table.
 .. warning::
 
     Storing complex types in Broker backed store comes with severe restrictions.
-    When you modify a stored complex type after inserting it into a table, this change
-    will *not propagate* to Broker and hence not be persisted/synchronized over the cluster.
-
-    To send out the new value, you will have to re-insert the complex type into the zeek table.
+    When you modify a stored complex type after inserting it into a table, that change in a stored complex type 
+    will *not propagate* to Broker. Hence to send out the new value, so that it will be persisted/synchronized
+    over the cluster, you will have to re-insert the complex type into the local zeek table.
 
     For example:
 
@@ -436,9 +434,9 @@ table.
 
             type testrec: record {
                 a: count;
-            }
+            };
 
-            global t: table[string] of testrec &backend=Broker::MEMORY;
+            global t: table[string] of testrec &broker_allow_complex_type &backend=Broker::MEMORY;
 
             event zeek_init()
                 {

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -1178,7 +1178,7 @@ add an entire new type to the scripting language.
 
 .. zeek:type:: paraglob
 
-  An opqaue type for creating and using paraglob data structures inside of
+  An opaque type for creating and using paraglob data structures inside of
   Zeek. A paraglob is a data structure for fast string matching against a
   large set of glob style patterns. It can be loaded with a vector of
   patterns, and then queried with input strings. Note that these patterns are

--- a/scripts/base/init-bare.zeek.rst
+++ b/scripts/base/init-bare.zeek.rst
@@ -572,8 +572,8 @@ Types
 :zeek:type:`endpoint`: :zeek:type:`record`                                    Statistics about a :zeek:type:`connection` endpoint.
 :zeek:type:`endpoint_stats`: :zeek:type:`record`                              Statistics about what a TCP endpoint sent.
 :zeek:type:`entropy_test_result`: :zeek:type:`record`                         Computed entropy values.
-:zeek:type:`fa_file`: :zeek:type:`record` :zeek:attr:`&redef`                 A file that Zeek is analyzing.
-:zeek:type:`fa_metadata`: :zeek:type:`record`                                 Metadata that's been inferred about a particular file.
+:zeek:type:`fa_file`: :zeek:type:`record` :zeek:attr:`&redef`                 File Analysis handle for a file that Zeek is analyzing.
+:zeek:type:`fa_metadata`: :zeek:type:`record`                                 File Analysis metadata that's been inferred about a particular file.
 :zeek:type:`files_tag_set`: :zeek:type:`set`                                  A set of file analyzer tags.
 :zeek:type:`flow_id`: :zeek:type:`record` :zeek:attr:`&log`                   The identifying 4-tuple of a uni-directional flow.
 :zeek:type:`ftp_port`: :zeek:type:`record`                                    A parsed host/port combination describing server endpoint for an upcoming
@@ -7770,7 +7770,7 @@ Types
    :Type: :zeek:type:`record`
 
       id: :zeek:type:`string`
-         An identifier associated with a single file.
+         A hash serving as the identifier associated with a single file.
 
       parent_id: :zeek:type:`string` :zeek:attr:`&optional`
          Identifier associated with a container file from which this one was
@@ -7779,8 +7779,9 @@ Types
       source: :zeek:type:`string`
          An identification of the source of the file data. E.g. it may be
          a network protocol over which it was transferred, or a local file
-         path which was read, or some other input source.
-         Examples are: "HTTP", "SMTP", "IRC_DATA", or the file path.
+         path including filename which was read, or some other input source.
+         Examples are: "HTTP", "SMTP", "IRC_DATA", or the filename, or even
+         the full path and filename.
 
       is_orig: :zeek:type:`bool` :zeek:attr:`&optional`
          If the source of this file is a network connection, this field
@@ -7851,10 +7852,11 @@ Types
 
    :Attributes: :zeek:attr:`&redef`
 
-   A file that Zeek is analyzing.  This is Zeek's type for describing the basic
-   internal metadata collected about a "file", which is essentially just a
-   byte stream that is e.g. pulled from a network connection or possibly
-   some other input source.
+   File Analysis handle for a file that Zeek is analyzing. This holds
+   information about, but not the content of, a conceptual "file";
+   essentially any byte stream that is e.g. pulled from a network connection
+   or possibly some other input source. Note that fa_file is also used in
+   cases where there isn't a filename to be had.
 
 .. zeek:type:: fa_metadata
 
@@ -7870,7 +7872,7 @@ Types
          Specifies whether the MIME type was inferred using signatures,
          or provided directly by the protocol the file appeared in.
 
-   Metadata that's been inferred about a particular file.
+   File Analysis metadata that's been inferred about a particular file.
 
 .. zeek:type:: files_tag_set
 


### PR DESCRIPTION
Improved the grammar in &broker_store and in &broker_allow_complex_type prose.

Added missing semicolon on the first type in the &broker_allow_complex_type example, and added a use of  &broker_allow_complex_type  into the example.