### PR TITLE
Debian 10: error: Could not find prerequisite package 'PythonDev'

### DIFF
--- a/install/install.rst
+++ b/install/install.rst
@@ -67,7 +67,7 @@ To install the required dependencies, you can use:
 
   .. code-block:: console
 
-     sudo apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev swig zlib1g-dev
+     sudo apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev libpython3-dev swig zlib1g-dev
 
 * FreeBSD:
 


### PR DESCRIPTION
Previously receiving error mentioned above since libpython3-dev package contents appeared to be missing in Debian 10 (buster).