### PR TITLE
Zeekygen docs update for cluster controller documentation

### DIFF
--- a/scripts/base/frameworks/supervisor/control.zeek.rst
+++ b/scripts/base/frameworks/supervisor/control.zeek.rst
@@ -92,7 +92,7 @@ Events
    :node: the desired configuration for the new supervised node process.
 
 .. zeek:id:: SupervisorControl::create_response
-   :source-code: policy/frameworks/cluster/agent/main.zeek 28 44
+   :source-code: policy/frameworks/cluster/agent/main.zeek 33 49
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`string`)
 
@@ -121,7 +121,7 @@ Events
          nodes".
 
 .. zeek:id:: SupervisorControl::destroy_response
-   :source-code: policy/frameworks/cluster/agent/main.zeek 46 62
+   :source-code: policy/frameworks/cluster/agent/main.zeek 51 67
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`bool`)
 

--- a/scripts/policy/frameworks/cluster/agent/__load__.zeek.rst
+++ b/scripts/policy/frameworks/cluster/agent/__load__.zeek.rst
@@ -3,6 +3,8 @@
 policy/frameworks/cluster/agent/__load__.zeek
 =============================================
 
+The entry point for the cluster agent. It runs bootstrap logic for launching
+the agent process via Zeek's Supervisor.
 
 :Imports: :doc:`policy/frameworks/cluster/agent/boot.zeek </scripts/policy/frameworks/cluster/agent/boot.zeek>`
 

--- a/scripts/policy/frameworks/cluster/agent/api.zeek.rst
+++ b/scripts/policy/frameworks/cluster/agent/api.zeek.rst
@@ -4,6 +4,10 @@ policy/frameworks/cluster/agent/api.zeek
 ========================================
 .. zeek:namespace:: ClusterAgent::API
 
+The event API of cluster agents. Most endpoints consist of event pairs,
+where the agent answers a request event with a corresponding response
+event. Such event pairs share the same name prefix and end in "_request" and
+"_response", respectively.
 
 :Namespace: ClusterAgent::API
 :Imports: :doc:`base/frameworks/supervisor/control.zeek </scripts/base/frameworks/supervisor/control.zeek>`, :doc:`policy/frameworks/cluster/controller/types.zeek </scripts/policy/frameworks/cluster/controller/types.zeek>`
@@ -12,24 +16,30 @@ Summary
 ~~~~~~~
 Constants
 #########
-========================================================= =
-:zeek:id:`ClusterAgent::API::version`: :zeek:type:`count` 
-========================================================= =
+========================================================= ================================================================
+:zeek:id:`ClusterAgent::API::version`: :zeek:type:`count` A simple versioning scheme, used to track basic compatibility of
+                                                          controller and agent.
+========================================================= ================================================================
 
 Events
 ######
-============================================================================ =
-:zeek:id:`ClusterAgent::API::agent_standby_request`: :zeek:type:`event`      
-:zeek:id:`ClusterAgent::API::agent_standby_response`: :zeek:type:`event`     
-:zeek:id:`ClusterAgent::API::agent_welcome_request`: :zeek:type:`event`      
-:zeek:id:`ClusterAgent::API::agent_welcome_response`: :zeek:type:`event`     
-:zeek:id:`ClusterAgent::API::notify_agent_hello`: :zeek:type:`event`         
+============================================================================ =====================================================================
+:zeek:id:`ClusterAgent::API::agent_standby_request`: :zeek:type:`event`      The controller sends this event to convey that the agent is not
+                                                                             currently required.
+:zeek:id:`ClusterAgent::API::agent_standby_response`: :zeek:type:`event`     Response to an agent_standby_request event.
+:zeek:id:`ClusterAgent::API::agent_welcome_request`: :zeek:type:`event`      The controller sends this event to confirm to the agent that it is
+                                                                             part of the current cluster topology.
+:zeek:id:`ClusterAgent::API::agent_welcome_response`: :zeek:type:`event`     Response to an agent_welcome_request event.
+:zeek:id:`ClusterAgent::API::notify_agent_hello`: :zeek:type:`event`         The agent sends this event upon peering as a "check-in", informing
+                                                                             the controller that an agent of the given name is now available to
+                                                                             communicate with.
 :zeek:id:`ClusterAgent::API::notify_change`: :zeek:type:`event`              
 :zeek:id:`ClusterAgent::API::notify_error`: :zeek:type:`event`               
 :zeek:id:`ClusterAgent::API::notify_log`: :zeek:type:`event`                 
-:zeek:id:`ClusterAgent::API::set_configuration_request`: :zeek:type:`event`  
-:zeek:id:`ClusterAgent::API::set_configuration_response`: :zeek:type:`event` 
-============================================================================ =
+:zeek:id:`ClusterAgent::API::set_configuration_request`: :zeek:type:`event`  The controller sends this event to convey a new cluster configuration
+                                                                             to the agent.
+:zeek:id:`ClusterAgent::API::set_configuration_response`: :zeek:type:`event` Response to a set_configuration_request event.
+============================================================================ =====================================================================
 
 
 Detailed Interface
@@ -37,72 +47,147 @@ Detailed Interface
 Constants
 #########
 .. zeek:id:: ClusterAgent::API::version
-   :source-code: policy/frameworks/cluster/agent/api.zeek 7 7
+   :source-code: policy/frameworks/cluster/agent/api.zeek 14 14
 
    :Type: :zeek:type:`count`
    :Default: ``1``
 
+   A simple versioning scheme, used to track basic compatibility of
+   controller and agent.
 
 Events
 ######
 .. zeek:id:: ClusterAgent::API::agent_standby_request
-   :source-code: policy/frameworks/cluster/agent/main.zeek 180 198
+   :source-code: policy/frameworks/cluster/agent/main.zeek 185 203
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`)
 
+   The controller sends this event to convey that the agent is not
+   currently required. This status may later change, depending on
+   updates from the client, so the Broker-level peering can remain
+   active. The agent releases any cluster-related resources (including
+   shutdown of existing Zeek cluster nodes) when processing the request,
+   and confirms via the response event. Shutting down an agent at this
+   point has no operational impact on the running cluster.
+   
+
+   :reqid: a request identifier string, echoed in the response event.
+   
 
 .. zeek:id:: ClusterAgent::API::agent_standby_response
-   :source-code: policy/frameworks/cluster/agent/api.zeek 32 32
+   :source-code: policy/frameworks/cluster/agent/api.zeek 83 83
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`ClusterController::Types::Result`)
 
+   Response to an agent_standby_request event. The agent sends this
+   back to the controller.
+   
+
+   :reqid: the request identifier used in the request event.
+   
+
+   :result: the result record.
+   
 
 .. zeek:id:: ClusterAgent::API::agent_welcome_request
-   :source-code: policy/frameworks/cluster/agent/main.zeek 167 178
+   :source-code: policy/frameworks/cluster/agent/main.zeek 172 183
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`)
 
+   The controller sends this event to confirm to the agent that it is
+   part of the current cluster topology. The agent acknowledges with the
+   corresponding response event.
+   
+
+   :reqid: a request identifier string, echoed in the response event.
+   
 
 .. zeek:id:: ClusterAgent::API::agent_welcome_response
-   :source-code: policy/frameworks/cluster/controller/main.zeek 226 253
+   :source-code: policy/frameworks/cluster/controller/main.zeek 231 258
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`ClusterController::Types::Result`)
 
+   Response to an agent_welcome_request event. The agent sends this
+   back to the controller.
+   
+
+   :reqid: the request identifier used in the request event.
+   
+
+   :result: the result record.
+   
 
 .. zeek:id:: ClusterAgent::API::notify_agent_hello
-   :source-code: policy/frameworks/cluster/controller/main.zeek 192 224
+   :source-code: policy/frameworks/cluster/controller/main.zeek 197 229
 
    :Type: :zeek:type:`event` (instance: :zeek:type:`string`, host: :zeek:type:`addr`, api_version: :zeek:type:`count`)
 
+   The agent sends this event upon peering as a "check-in", informing
+   the controller that an agent of the given name is now available to
+   communicate with. It is a controller-level equivalent of
+   `:zeek:see:`Broker::peer_added`.
+   
+
+   :instance: an instance name, really the agent's name as per :zeek:see:`ClusterAgent::name`.
+   
+
+   :host: the IP address of the agent. (This may change in the future.)
+   
+
+   :api_version: the API version of this agent.
+   
 
 .. zeek:id:: ClusterAgent::API::notify_change
-   :source-code: policy/frameworks/cluster/controller/main.zeek 257 258
+   :source-code: policy/frameworks/cluster/controller/main.zeek 262 263
 
    :Type: :zeek:type:`event` (instance: :zeek:type:`string`, n: :zeek:type:`ClusterController::Types::Node`, old: :zeek:type:`ClusterController::Types::State`, new: :zeek:type:`ClusterController::Types::State`)
 
 
 .. zeek:id:: ClusterAgent::API::notify_error
-   :source-code: policy/frameworks/cluster/controller/main.zeek 262 263
-
-   :Type: :zeek:type:`event` (instance: :zeek:type:`string`, msg: :zeek:type:`string`, node: :zeek:type:`string` :zeek:attr:`&default` = ``""`` :zeek:attr:`&optional`)
-
-
-.. zeek:id:: ClusterAgent::API::notify_log
    :source-code: policy/frameworks/cluster/controller/main.zeek 267 268
 
    :Type: :zeek:type:`event` (instance: :zeek:type:`string`, msg: :zeek:type:`string`, node: :zeek:type:`string` :zeek:attr:`&default` = ``""`` :zeek:attr:`&optional`)
 
 
+.. zeek:id:: ClusterAgent::API::notify_log
+   :source-code: policy/frameworks/cluster/controller/main.zeek 272 273
+
+   :Type: :zeek:type:`event` (instance: :zeek:type:`string`, msg: :zeek:type:`string`, node: :zeek:type:`string` :zeek:attr:`&default` = ``""`` :zeek:attr:`&optional`)
+
+
 .. zeek:id:: ClusterAgent::API::set_configuration_request
-   :source-code: policy/frameworks/cluster/agent/main.zeek 80 166
+   :source-code: policy/frameworks/cluster/agent/main.zeek 85 171
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, config: :zeek:type:`ClusterController::Types::Configuration`)
 
+   The controller sends this event to convey a new cluster configuration
+   to the agent. Once processed, the agent responds with the response
+   event.
+   
+
+   :reqid: a request identifier string, echoed in the response event.
+   
+
+   :config: a :zeek:see:`ClusterController::Types::Configuration` record
+       describing the cluster topology. Note that this contains the full
+       topology, not just the part pertaining to this agent. That's because
+       the cluster framework requires full cluster visibility to establish
+       the needed peerings.
+   
 
 .. zeek:id:: ClusterAgent::API::set_configuration_response
-   :source-code: policy/frameworks/cluster/controller/main.zeek 272 345
+   :source-code: policy/frameworks/cluster/controller/main.zeek 277 350
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`ClusterController::Types::Result`)
 
+   Response to a set_configuration_request event. The agent sends
+   this back to the controller.
+   
+
+   :reqid: the request identifier used in the request event.
+   
+
+   :result: the result record.
+   
 
 

--- a/scripts/policy/frameworks/cluster/agent/boot.zeek.rst
+++ b/scripts/policy/frameworks/cluster/agent/boot.zeek.rst
@@ -3,6 +3,11 @@
 policy/frameworks/cluster/agent/boot.zeek
 =========================================
 
+The cluster agent boot logic runs in Zeek's supervisor and instructs it to
+launch an agent process. The agent's main logic resides in main.zeek,
+similarly to other frameworks. The new process will execute that script.
+
+If the current process is not the Zeek supervisor, this does nothing.
 
 :Imports: :doc:`policy/frameworks/cluster/agent/config.zeek </scripts/policy/frameworks/cluster/agent/config.zeek>`
 

--- a/scripts/policy/frameworks/cluster/agent/config.zeek.rst
+++ b/scripts/policy/frameworks/cluster/agent/config.zeek.rst
@@ -4,6 +4,7 @@ policy/frameworks/cluster/agent/config.zeek
 ===========================================
 .. zeek:namespace:: ClusterAgent
 
+Configuration settings for a cluster agent.
 
 :Namespace: ClusterAgent
 :Imports: :doc:`policy/frameworks/cluster/controller/types.zeek </scripts/policy/frameworks/cluster/controller/types.zeek>`
@@ -12,26 +13,31 @@ Summary
 ~~~~~~~
 Redefinable Options
 ###################
-========================================================================================= =
-:zeek:id:`ClusterAgent::cluster_directory`: :zeek:type:`string` :zeek:attr:`&redef`       
-:zeek:id:`ClusterAgent::controller`: :zeek:type:`Broker::NetworkInfo` :zeek:attr:`&redef` 
-:zeek:id:`ClusterAgent::default_address`: :zeek:type:`string` :zeek:attr:`&redef`         
-:zeek:id:`ClusterAgent::default_port`: :zeek:type:`port` :zeek:attr:`&redef`              
-:zeek:id:`ClusterAgent::directory`: :zeek:type:`string` :zeek:attr:`&redef`               
-:zeek:id:`ClusterAgent::listen_address`: :zeek:type:`string` :zeek:attr:`&redef`          
-:zeek:id:`ClusterAgent::listen_port`: :zeek:type:`string` :zeek:attr:`&redef`             
-:zeek:id:`ClusterAgent::name`: :zeek:type:`string` :zeek:attr:`&redef`                    
-:zeek:id:`ClusterAgent::stderr_file_suffix`: :zeek:type:`string` :zeek:attr:`&redef`      
-:zeek:id:`ClusterAgent::stdout_file_suffix`: :zeek:type:`string` :zeek:attr:`&redef`      
-:zeek:id:`ClusterAgent::topic_prefix`: :zeek:type:`string` :zeek:attr:`&redef`            
-========================================================================================= =
+========================================================================================= ================================================================================
+:zeek:id:`ClusterAgent::cluster_directory`: :zeek:type:`string` :zeek:attr:`&redef`       The working directory for data cluster nodes created by this
+                                                                                          agent.
+:zeek:id:`ClusterAgent::controller`: :zeek:type:`Broker::NetworkInfo` :zeek:attr:`&redef` The network coordinates of the controller.
+:zeek:id:`ClusterAgent::default_address`: :zeek:type:`string` :zeek:attr:`&redef`         The fallback listen address if :zeek:see:`ClusterAgent::listen_address`
+                                                                                          remains empty.
+:zeek:id:`ClusterAgent::default_port`: :zeek:type:`port` :zeek:attr:`&redef`              The fallback listen port if :zeek:see:`ClusterAgent::listen_port` remains empty.
+:zeek:id:`ClusterAgent::directory`: :zeek:type:`string` :zeek:attr:`&redef`               An optional custom output directory for the agent's stdout and stderr
+                                                                                          logs.
+:zeek:id:`ClusterAgent::listen_address`: :zeek:type:`string` :zeek:attr:`&redef`          The network address the agent listens on.
+:zeek:id:`ClusterAgent::listen_port`: :zeek:type:`string` :zeek:attr:`&redef`             The network port the agent listens on.
+:zeek:id:`ClusterAgent::name`: :zeek:type:`string` :zeek:attr:`&redef`                    The name this agent uses to represent the cluster instance it
+                                                                                          manages.
+:zeek:id:`ClusterAgent::stderr_file_suffix`: :zeek:type:`string` :zeek:attr:`&redef`      Agent stderr log configuration.
+:zeek:id:`ClusterAgent::stdout_file_suffix`: :zeek:type:`string` :zeek:attr:`&redef`      Agent stdout log configuration.
+:zeek:id:`ClusterAgent::topic_prefix`: :zeek:type:`string` :zeek:attr:`&redef`            The agent's Broker topic prefix.
+========================================================================================= ================================================================================
 
 Functions
 #########
-============================================================= =
-:zeek:id:`ClusterAgent::endpoint_info`: :zeek:type:`function` 
-:zeek:id:`ClusterAgent::instance`: :zeek:type:`function`      
-============================================================= =
+============================================================= ========================================================================
+:zeek:id:`ClusterAgent::endpoint_info`: :zeek:type:`function` Returns a :zeek:see:`Broker::EndpointInfo` record for this instance.
+:zeek:id:`ClusterAgent::instance`: :zeek:type:`function`      Returns a :zeek:see:`ClusterController::Types::Instance` describing this
+                                                              instance (its agent name plus listening address/port, as applicable).
+============================================================= ========================================================================
 
 
 Detailed Interface
@@ -39,15 +45,19 @@ Detailed Interface
 Redefinable Options
 ###################
 .. zeek:id:: ClusterAgent::cluster_directory
-   :source-code: policy/frameworks/cluster/agent/config.zeek 44 44
+   :source-code: policy/frameworks/cluster/agent/config.zeek 72 72
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The working directory for data cluster nodes created by this
+   agent. If you make this a relative path, note that the path is
+   relative to the agent's working directory, since it creates data
+   cluster nodes.
 
 .. zeek:id:: ClusterAgent::controller
-   :source-code: policy/frameworks/cluster/agent/config.zeek 32 32
+   :source-code: policy/frameworks/cluster/agent/config.zeek 58 58
 
    :Type: :zeek:type:`Broker::NetworkInfo`
    :Attributes: :zeek:attr:`&redef`
@@ -61,91 +71,135 @@ Redefinable Options
          }
 
 
+   The network coordinates of the controller. When defined, the agent
+   peers with (and connects to) the controller; otherwise the controller
+   will peer (and connect to) the agent, listening as defined by
+   :zeek:see:`ClusterAgent::listen_address` and :zeek:see:`ClusterAgent::listen_port`.
 
 .. zeek:id:: ClusterAgent::default_address
-   :source-code: policy/frameworks/cluster/agent/config.zeek 20 20
+   :source-code: policy/frameworks/cluster/agent/config.zeek 40 40
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The fallback listen address if :zeek:see:`ClusterAgent::listen_address`
+   remains empty. Unless redefined, this uses Broker's own default listen
+   address.
 
 .. zeek:id:: ClusterAgent::default_port
-   :source-code: policy/frameworks/cluster/agent/config.zeek 23 23
+   :source-code: policy/frameworks/cluster/agent/config.zeek 48 48
 
    :Type: :zeek:type:`port`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``2151/tcp``
 
+   The fallback listen port if :zeek:see:`ClusterAgent::listen_port` remains empty.
 
 .. zeek:id:: ClusterAgent::directory
-   :source-code: policy/frameworks/cluster/agent/config.zeek 39 39
+   :source-code: policy/frameworks/cluster/agent/config.zeek 66 66
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   An optional custom output directory for the agent's stdout and stderr
+   logs. Agent and controller currently only log locally, not via the
+   data cluster's logger node. (This might change in the future.) This
+   means that if both write to the same log file, the output gets
+   garbled.
 
 .. zeek:id:: ClusterAgent::listen_address
-   :source-code: policy/frameworks/cluster/agent/config.zeek 19 19
+   :source-code: policy/frameworks/cluster/agent/config.zeek 35 35
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The network address the agent listens on. This only takes effect if
+   the agent isn't configured to connect to the controller (see
+   :zeek:see:`ClusterAgent::controller`). By default this uses the value of the
+   ZEEK_AGENT_ADDR environment variable, but you may also redef to
+   a specific value. When empty, the implementation falls back to
+   :zeek:see:`ClusterAgent::default_address`.
 
 .. zeek:id:: ClusterAgent::listen_port
-   :source-code: policy/frameworks/cluster/agent/config.zeek 22 22
+   :source-code: policy/frameworks/cluster/agent/config.zeek 45 45
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The network port the agent listens on. Counterpart to
+   :zeek:see:`ClusterAgent::listen_address`, defaulting to the ZEEK_AGENT_PORT
+   environment variable.
 
 .. zeek:id:: ClusterAgent::name
-   :source-code: policy/frameworks/cluster/agent/config.zeek 9 9
+   :source-code: policy/frameworks/cluster/agent/config.zeek 12 12
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The name this agent uses to represent the cluster instance it
+   manages. Defaults to the value of the ZEEK_AGENT_NAME environment
+   variable. When that is unset and you don't redef the value,
+   the implementation defaults to "agent-<hostname>".
 
 .. zeek:id:: ClusterAgent::stderr_file_suffix
-   :source-code: policy/frameworks/cluster/agent/config.zeek 15 15
+   :source-code: policy/frameworks/cluster/agent/config.zeek 27 27
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``"agent.stderr"``
 
+   Agent stderr log configuration. Like :zeek:see:`ClusterAgent::stdout_file_suffix`,
+   but for the stderr stream.
 
 .. zeek:id:: ClusterAgent::stdout_file_suffix
-   :source-code: policy/frameworks/cluster/agent/config.zeek 14 14
+   :source-code: policy/frameworks/cluster/agent/config.zeek 23 23
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``"agent.stdout"``
 
+   Agent stdout log configuration. If the string is non-empty, Zeek will
+   produce a free-form log (i.e., not one governed by Zeek's logging
+   framework) in Zeek's working directory. The final log's name is
+   "<name>.<suffix>", where the name is taken from :zeek:see:`ClusterAgent::name`,
+   and the suffix is defined by the following variable. If left empty,
+   no such log results.
+   
+   Note that the agent also establishes a "proper" Zeek log via the
+   :zeek:see:`ClusterController::Log` module.
 
 .. zeek:id:: ClusterAgent::topic_prefix
-   :source-code: policy/frameworks/cluster/agent/config.zeek 27 27
+   :source-code: policy/frameworks/cluster/agent/config.zeek 52 52
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``"zeek/cluster-control/agent"``
 
+   The agent's Broker topic prefix. For its own communication, the agent
+   suffixes this with "/<name>", based on :zeek:see:`ClusterAgent::name`.
 
 Functions
 #########
 .. zeek:id:: ClusterAgent::endpoint_info
-   :source-code: policy/frameworks/cluster/agent/config.zeek 60 86
+   :source-code: policy/frameworks/cluster/agent/config.zeek 92 118
 
    :Type: :zeek:type:`function` () : :zeek:type:`Broker::EndpointInfo`
 
+   Returns a :zeek:see:`Broker::EndpointInfo` record for this instance.
+   Similar to :zeek:see:`ClusterAgent::instance`, but with slightly different
+   data format.
 
 .. zeek:id:: ClusterAgent::instance
-   :source-code: policy/frameworks/cluster/agent/config.zeek 52 58
+   :source-code: policy/frameworks/cluster/agent/config.zeek 84 90
 
    :Type: :zeek:type:`function` () : :zeek:type:`ClusterController::Types::Instance`
 
+   Returns a :zeek:see:`ClusterController::Types::Instance` describing this
+   instance (its agent name plus listening address/port, as applicable).
 
 

--- a/scripts/policy/frameworks/cluster/agent/index.rst
+++ b/scripts/policy/frameworks/cluster/agent/index.rst
@@ -6,16 +6,32 @@ Package: policy/frameworks/cluster/agent
 
 :doc:`/scripts/policy/frameworks/cluster/agent/__load__.zeek`
 
+   The entry point for the cluster agent. It runs bootstrap logic for launching
+   the agent process via Zeek's Supervisor.
 
 :doc:`/scripts/policy/frameworks/cluster/agent/boot.zeek`
 
+   The cluster agent boot logic runs in Zeek's supervisor and instructs it to
+   launch an agent process. The agent's main logic resides in main.zeek,
+   similarly to other frameworks. The new process will execute that script.
+   
+   If the current process is not the Zeek supervisor, this does nothing.
 
 :doc:`/scripts/policy/frameworks/cluster/agent/config.zeek`
 
+   Configuration settings for a cluster agent.
 
 :doc:`/scripts/policy/frameworks/cluster/agent/api.zeek`
 
+   The event API of cluster agents. Most endpoints consist of event pairs,
+   where the agent answers a request event with a corresponding response
+   event. Such event pairs share the same name prefix and end in "_request" and
+   "_response", respectively.
 
 :doc:`/scripts/policy/frameworks/cluster/agent/main.zeek`
 
+   This is the main "runtime" of a cluster agent. Zeek does not load this
+   directly; rather, the agent's bootstrapping module (in ./boot.zeek)
+   specifies it as the script to run in the node newly created via Zeek's
+   supervisor.
 

--- a/scripts/policy/frameworks/cluster/agent/main.zeek.rst
+++ b/scripts/policy/frameworks/cluster/agent/main.zeek.rst
@@ -4,6 +4,10 @@ policy/frameworks/cluster/agent/main.zeek
 =========================================
 .. zeek:namespace:: ClusterAgent::Runtime
 
+This is the main "runtime" of a cluster agent. Zeek does not load this
+directly; rather, the agent's bootstrapping module (in ./boot.zeek)
+specifies it as the script to run in the node newly created via Zeek's
+supervisor.
 
 :Namespace: ClusterAgent::Runtime
 :Imports: :doc:`base/frameworks/broker </scripts/base/frameworks/broker/index>`, :doc:`policy/frameworks/cluster/agent/api.zeek </scripts/policy/frameworks/cluster/agent/api.zeek>`, :doc:`policy/frameworks/cluster/controller/config.zeek </scripts/policy/frameworks/cluster/controller/config.zeek>`, :doc:`policy/frameworks/cluster/controller/log.zeek </scripts/policy/frameworks/cluster/controller/log.zeek>`, :doc:`policy/frameworks/cluster/controller/request.zeek </scripts/policy/frameworks/cluster/controller/request.zeek>`

--- a/scripts/policy/frameworks/cluster/controller/__load__.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/__load__.zeek.rst
@@ -3,6 +3,8 @@
 policy/frameworks/cluster/controller/__load__.zeek
 ==================================================
 
+The entry point for the cluster controller. It runs bootstrap logic for
+launching the controller process via Zeek's Supervisor.
 
 :Imports: :doc:`policy/frameworks/cluster/controller/boot.zeek </scripts/policy/frameworks/cluster/controller/boot.zeek>`
 

--- a/scripts/policy/frameworks/cluster/controller/api.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/api.zeek.rst
@@ -4,6 +4,10 @@ policy/frameworks/cluster/controller/api.zeek
 =============================================
 .. zeek:namespace:: ClusterController::API
 
+The event API of cluster controllers. Most endpoints consist of event pairs,
+where the controller answers a zeek-client request event with a
+corresponding response event. Such event pairs share the same name prefix
+and end in "_request" and "_response", respectively.
 
 :Namespace: ClusterController::API
 :Imports: :doc:`policy/frameworks/cluster/controller/types.zeek </scripts/policy/frameworks/cluster/controller/types.zeek>`
@@ -12,21 +16,27 @@ Summary
 ~~~~~~~
 Constants
 #########
-============================================================== =
-:zeek:id:`ClusterController::API::version`: :zeek:type:`count` 
-============================================================== =
+============================================================== ================================================================
+:zeek:id:`ClusterController::API::version`: :zeek:type:`count` A simple versioning scheme, used to track basic compatibility of
+                                                               controller, agents, and zeek-client.
+============================================================== ================================================================
 
 Events
 ######
-================================================================================= =
-:zeek:id:`ClusterController::API::get_instances_request`: :zeek:type:`event`      
-:zeek:id:`ClusterController::API::get_instances_response`: :zeek:type:`event`     
-:zeek:id:`ClusterController::API::notify_agents_ready`: :zeek:type:`event`        
-:zeek:id:`ClusterController::API::set_configuration_request`: :zeek:type:`event`  
-:zeek:id:`ClusterController::API::set_configuration_response`: :zeek:type:`event` 
-:zeek:id:`ClusterController::API::test_timeout_request`: :zeek:type:`event`       
-:zeek:id:`ClusterController::API::test_timeout_response`: :zeek:type:`event`      
-================================================================================= =
+================================================================================= ======================================================================
+:zeek:id:`ClusterController::API::get_instances_request`: :zeek:type:`event`      zeek-client sends this event to request a list of the currently
+                                                                                  peered agents/instances.
+:zeek:id:`ClusterController::API::get_instances_response`: :zeek:type:`event`     Response to a get_instances_request event.
+:zeek:id:`ClusterController::API::notify_agents_ready`: :zeek:type:`event`        The controller triggers this event when the operational cluster
+                                                                                  instances align with the ones desired by the cluster
+                                                                                  configuration.
+:zeek:id:`ClusterController::API::set_configuration_request`: :zeek:type:`event`  zeek-client sends this event to establish a new cluster configuration,
+                                                                                  including the full cluster topology.
+:zeek:id:`ClusterController::API::set_configuration_response`: :zeek:type:`event` Response to a set_configuration_request event.
+:zeek:id:`ClusterController::API::test_timeout_request`: :zeek:type:`event`       This event causes no further action (other than getting logged) if
+                                                                                  with_state is F.
+:zeek:id:`ClusterController::API::test_timeout_response`: :zeek:type:`event`      Response to a test_timeout_request event.
+================================================================================= ======================================================================
 
 
 Detailed Interface
@@ -34,54 +44,122 @@ Detailed Interface
 Constants
 #########
 .. zeek:id:: ClusterController::API::version
-   :source-code: policy/frameworks/cluster/controller/api.zeek 6 6
+   :source-code: policy/frameworks/cluster/controller/api.zeek 13 13
 
    :Type: :zeek:type:`count`
    :Default: ``1``
 
+   A simple versioning scheme, used to track basic compatibility of
+   controller, agents, and zeek-client.
 
 Events
 ######
 .. zeek:id:: ClusterController::API::get_instances_request
-   :source-code: policy/frameworks/cluster/controller/main.zeek 457 472
+   :source-code: policy/frameworks/cluster/controller/main.zeek 462 477
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`)
 
+   zeek-client sends this event to request a list of the currently
+   peered agents/instances.
+   
+
+   :reqid: a request identifier string, echoed in the response event.
+   
 
 .. zeek:id:: ClusterController::API::get_instances_response
-   :source-code: policy/frameworks/cluster/controller/api.zeek 13 13
+   :source-code: policy/frameworks/cluster/controller/api.zeek 31 31
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`ClusterController::Types::Result`)
 
+   Response to a get_instances_request event. The controller sends
+   this back to the client.
+   
+
+   :reqid: the request identifier used in the request event.
+   
+
+   :result: the result record. Its data member is a
+       :zeek:see:`ClusterController::Types::Instance` record.
+   
 
 .. zeek:id:: ClusterController::API::notify_agents_ready
-   :source-code: policy/frameworks/cluster/controller/main.zeek 172 190
+   :source-code: policy/frameworks/cluster/controller/main.zeek 177 195
 
    :Type: :zeek:type:`event` (instances: :zeek:type:`set` [:zeek:type:`string`])
 
+   The controller triggers this event when the operational cluster
+   instances align with the ones desired by the cluster
+   configuration. It's essentially a cluster management readiness
+   event. This event is currently only used by the controller and not
+   published to other topics.
+   
+
+   :instances: the set of instance names now ready.
+   
 
 .. zeek:id:: ClusterController::API::set_configuration_request
-   :source-code: policy/frameworks/cluster/controller/main.zeek 346 456
+   :source-code: policy/frameworks/cluster/controller/main.zeek 351 461
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, config: :zeek:type:`ClusterController::Types::Configuration`)
 
+   zeek-client sends this event to establish a new cluster configuration,
+   including the full cluster topology. The controller processes the update
+   and relays it to the agents. Once each has responded (or a timeout occurs)
+   the controller sends a corresponding response event back to the client.
+   
+
+   :reqid: a request identifier string, echoed in the response event.
+   
+
+   :config: a :zeek:see:`ClusterController::Types::Configuration` record
+       specifying the cluster configuration.
+   
 
 .. zeek:id:: ClusterController::API::set_configuration_response
-   :source-code: policy/frameworks/cluster/controller/api.zeek 18 18
+   :source-code: policy/frameworks/cluster/controller/api.zeek 56 56
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`ClusterController::Types::ResultVec`)
 
+   Response to a set_configuration_request event. The controller sends
+   this back to the client.
+   
+
+   :reqid: the request identifier used in the request event.
+   
+
+   :result: a vector of :zeek:see:`ClusterController::Types::Result` records.
+       Each member captures one agent's response.
+   
 
 .. zeek:id:: ClusterController::API::test_timeout_request
-   :source-code: policy/frameworks/cluster/controller/main.zeek 507 518
+   :source-code: policy/frameworks/cluster/controller/main.zeek 512 523
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, with_state: :zeek:type:`bool`)
 
+   This event causes no further action (other than getting logged) if
+   with_state is F. When T, the controller establishes request state, and
+   the controller only ever sends the response event when this state times
+   out.
+   
+
+   :reqid: a request identifier string, echoed in the response event when
+       with_state is T.
+   
+
+   :with_state: flag indicating whether the controller should keep (and
+       time out) request state for this request.
+   
 
 .. zeek:id:: ClusterController::API::test_timeout_response
-   :source-code: policy/frameworks/cluster/controller/api.zeek 29 29
+   :source-code: policy/frameworks/cluster/controller/api.zeek 81 81
 
    :Type: :zeek:type:`event` (reqid: :zeek:type:`string`, result: :zeek:type:`ClusterController::Types::Result`)
 
+   Response to a test_timeout_request event. The controller sends this
+   back to the client if the original request had the with_state flag.
+   
+
+   :reqid: the request identifier used in the request event.
+   
 
 

--- a/scripts/policy/frameworks/cluster/controller/boot.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/boot.zeek.rst
@@ -3,6 +3,12 @@
 policy/frameworks/cluster/controller/boot.zeek
 ==============================================
 
+The cluster controller's boot logic runs in Zeek's supervisor and instructs
+it to launch the controller process. The controller's main logic resides in
+main.zeek, similarly to other frameworks. The new process will execute that
+script.
+
+If the current process is not the Zeek supervisor, this does nothing.
 
 :Imports: :doc:`policy/frameworks/cluster/controller/config.zeek </scripts/policy/frameworks/cluster/controller/config.zeek>`
 

--- a/scripts/policy/frameworks/cluster/controller/config.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/config.zeek.rst
@@ -4,6 +4,7 @@ policy/frameworks/cluster/controller/config.zeek
 ================================================
 .. zeek:namespace:: ClusterController
 
+Configuration settings for the cluster controller.
 
 :Namespace: ClusterController
 :Imports: :doc:`policy/frameworks/cluster/agent/config.zeek </scripts/policy/frameworks/cluster/agent/config.zeek>`
@@ -12,27 +13,30 @@ Summary
 ~~~~~~~
 Redefinable Options
 ###################
-=================================================================================================== =
-:zeek:id:`ClusterController::connect_retry`: :zeek:type:`interval` :zeek:attr:`&redef`              
-:zeek:id:`ClusterController::default_address`: :zeek:type:`string` :zeek:attr:`&redef`              
-:zeek:id:`ClusterController::default_port`: :zeek:type:`port` :zeek:attr:`&redef`                   
-:zeek:id:`ClusterController::directory`: :zeek:type:`string` :zeek:attr:`&redef`                    
-:zeek:id:`ClusterController::listen_address`: :zeek:type:`string` :zeek:attr:`&redef`               
-:zeek:id:`ClusterController::listen_port`: :zeek:type:`string` :zeek:attr:`&redef`                  
-:zeek:id:`ClusterController::name`: :zeek:type:`string` :zeek:attr:`&redef`                         
-:zeek:id:`ClusterController::request_timeout`: :zeek:type:`interval` :zeek:attr:`&redef`            
-:zeek:id:`ClusterController::role`: :zeek:type:`ClusterController::Types::Role` :zeek:attr:`&redef` 
-:zeek:id:`ClusterController::stderr_file`: :zeek:type:`string` :zeek:attr:`&redef`                  
-:zeek:id:`ClusterController::stdout_file`: :zeek:type:`string` :zeek:attr:`&redef`                  
-:zeek:id:`ClusterController::topic`: :zeek:type:`string` :zeek:attr:`&redef`                        
-=================================================================================================== =
+=================================================================================================== ============================================================================
+:zeek:id:`ClusterController::connect_retry`: :zeek:type:`interval` :zeek:attr:`&redef`              The controller's connect retry interval.
+:zeek:id:`ClusterController::default_address`: :zeek:type:`string` :zeek:attr:`&redef`              The fallback listen address if :zeek:see:`ClusterController::listen_address`
+                                                                                                    remains empty.
+:zeek:id:`ClusterController::default_port`: :zeek:type:`port` :zeek:attr:`&redef`                   The fallback listen port if :zeek:see:`ClusterController::listen_port`
+                                                                                                    remains empty.
+:zeek:id:`ClusterController::directory`: :zeek:type:`string` :zeek:attr:`&redef`                    An optional custom output directory for the controller's stdout and
+                                                                                                    stderr logs.
+:zeek:id:`ClusterController::listen_address`: :zeek:type:`string` :zeek:attr:`&redef`               The network address the controller listens on.
+:zeek:id:`ClusterController::listen_port`: :zeek:type:`string` :zeek:attr:`&redef`                  The network port the controller listens on.
+:zeek:id:`ClusterController::name`: :zeek:type:`string` :zeek:attr:`&redef`                         The name of this controller.
+:zeek:id:`ClusterController::request_timeout`: :zeek:type:`interval` :zeek:attr:`&redef`            The timeout for request state.
+:zeek:id:`ClusterController::role`: :zeek:type:`ClusterController::Types::Role` :zeek:attr:`&redef` The role of this process in cluster management.
+:zeek:id:`ClusterController::stderr_file`: :zeek:type:`string` :zeek:attr:`&redef`                  The controller's stderr log name.
+:zeek:id:`ClusterController::stdout_file`: :zeek:type:`string` :zeek:attr:`&redef`                  The controller's stdout log name.
+:zeek:id:`ClusterController::topic`: :zeek:type:`string` :zeek:attr:`&redef`                        The controller's Broker topic.
+=================================================================================================== ============================================================================
 
 Functions
 #########
-================================================================== =
-:zeek:id:`ClusterController::endpoint_info`: :zeek:type:`function` 
-:zeek:id:`ClusterController::network_info`: :zeek:type:`function`  
-================================================================== =
+================================================================== ============================================================================
+:zeek:id:`ClusterController::endpoint_info`: :zeek:type:`function` Returns a :zeek:see:`Broker::EndpointInfo` record describing the controller.
+:zeek:id:`ClusterController::network_info`: :zeek:type:`function`  Returns a :zeek:see:`Broker::NetworkInfo` record describing the controller.
+================================================================== ============================================================================
 
 
 Detailed Interface
@@ -40,71 +44,99 @@ Detailed Interface
 Redefinable Options
 ###################
 .. zeek:id:: ClusterController::connect_retry
-   :source-code: policy/frameworks/cluster/controller/config.zeek 26 26
+   :source-code: policy/frameworks/cluster/controller/config.zeek 49 49
 
    :Type: :zeek:type:`interval`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``1.0 sec``
 
+   The controller's connect retry interval. Defaults to a more
+   aggressive value compared to Broker's 30s.
 
 .. zeek:id:: ClusterController::default_address
-   :source-code: policy/frameworks/cluster/controller/config.zeek 20 20
+   :source-code: policy/frameworks/cluster/controller/config.zeek 36 36
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The fallback listen address if :zeek:see:`ClusterController::listen_address`
+   remains empty. Unless redefined, this uses Broker's own default
+   listen address.
 
 .. zeek:id:: ClusterController::default_port
-   :source-code: policy/frameworks/cluster/controller/config.zeek 23 23
+   :source-code: policy/frameworks/cluster/controller/config.zeek 45 45
 
    :Type: :zeek:type:`port`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``2150/tcp``
 
+   The fallback listen port if :zeek:see:`ClusterController::listen_port`
+   remains empty.
 
 .. zeek:id:: ClusterController::directory
-   :source-code: policy/frameworks/cluster/controller/config.zeek 44 44
+   :source-code: policy/frameworks/cluster/controller/config.zeek 70 70
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   An optional custom output directory for the controller's stdout and
+   stderr logs. Agent and controller currently only log locally, not via
+   the data cluster's logger node. (This might change in the future.)
+   This means that if both write to the same log file, the output gets
+   garbled.
 
 .. zeek:id:: ClusterController::listen_address
-   :source-code: policy/frameworks/cluster/controller/config.zeek 19 19
+   :source-code: policy/frameworks/cluster/controller/config.zeek 31 31
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The network address the controller listens on. By default this uses
+   the value of the ZEEK_CONTROLLER_ADDR environment variable, but you
+   may also redef to a specific value. When empty, the implementation
+   falls back to :zeek:see:`ClusterController::default_address`.
 
 .. zeek:id:: ClusterController::listen_port
-   :source-code: policy/frameworks/cluster/controller/config.zeek 22 22
+   :source-code: policy/frameworks/cluster/controller/config.zeek 41 41
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The network port the controller listens on. Counterpart to
+   :zeek:see:`ClusterController::listen_address`, defaulting to the
+   ZEEK_CONTROLLER_PORT environment variable.
 
 .. zeek:id:: ClusterController::name
-   :source-code: policy/frameworks/cluster/controller/config.zeek 9 9
+   :source-code: policy/frameworks/cluster/controller/config.zeek 12 12
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``""``
 
+   The name of this controller. Defaults to the value of the
+   ZEEK_CONTROLLER_NAME environment variable. When that is unset and the
+   user doesn't redef the value, the implementation defaults to
+   "controller-<hostname>".
 
 .. zeek:id:: ClusterController::request_timeout
-   :source-code: policy/frameworks/cluster/controller/config.zeek 38 38
+   :source-code: policy/frameworks/cluster/controller/config.zeek 63 63
 
    :Type: :zeek:type:`interval`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``10.0 secs``
 
+   The timeout for request state. Such state (see the :zeek:see:`ClusterController::Request`
+   module) ties together request and response event pairs. The timeout causes
+   its cleanup in the absence of a timely response. It applies both to
+   state kept for client requests, as well as state in the agents for
+   requests to the supervisor.
 
 .. zeek:id:: ClusterController::role
-   :source-code: policy/frameworks/cluster/controller/config.zeek 33 33
+   :source-code: policy/frameworks/cluster/controller/config.zeek 56 56
 
    :Type: :zeek:type:`ClusterController::Types::Role`
    :Attributes: :zeek:attr:`&redef`
@@ -122,43 +154,57 @@ Redefinable Options
          ClusterController::Types::CONTROLLER
 
 
+   The role of this process in cluster management. Agent and controller
+   both redefine this. Used during logging.
 
 .. zeek:id:: ClusterController::stderr_file
-   :source-code: policy/frameworks/cluster/controller/config.zeek 14 14
+   :source-code: policy/frameworks/cluster/controller/config.zeek 25 25
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``"controller.stderr"``
 
+   The controller's stderr log name. Like :zeek:see:`ClusterController::stdout_file`,
+   but for the stderr stream.
 
 .. zeek:id:: ClusterController::stdout_file
-   :source-code: policy/frameworks/cluster/controller/config.zeek 13 13
+   :source-code: policy/frameworks/cluster/controller/config.zeek 21 21
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``"controller.stdout"``
 
+   The controller's stdout log name. If the string is non-empty, Zeek will
+   produce a free-form log (i.e., not one governed by Zeek's logging
+   framework) in Zeek's working directory. If left empty, no such log
+   results.
+   
+   Note that the controller also establishes a "proper" Zeek log via the
+   :zeek:see:`ClusterController::Log` module.
 
 .. zeek:id:: ClusterController::topic
-   :source-code: policy/frameworks/cluster/controller/config.zeek 29 29
+   :source-code: policy/frameworks/cluster/controller/config.zeek 52 52
 
    :Type: :zeek:type:`string`
    :Attributes: :zeek:attr:`&redef`
    :Default: ``"zeek/cluster-control/controller"``
 
+   The controller's Broker topic. Clients send requests to this topic.
 
 Functions
 #########
 .. zeek:id:: ClusterController::endpoint_info
-   :source-code: policy/frameworks/cluster/controller/config.zeek 71 84
+   :source-code: policy/frameworks/cluster/controller/config.zeek 98 111
 
    :Type: :zeek:type:`function` () : :zeek:type:`Broker::EndpointInfo`
 
+   Returns a :zeek:see:`Broker::EndpointInfo` record describing the controller.
 
 .. zeek:id:: ClusterController::network_info
-   :source-code: policy/frameworks/cluster/controller/config.zeek 52 70
+   :source-code: policy/frameworks/cluster/controller/config.zeek 79 97
 
    :Type: :zeek:type:`function` () : :zeek:type:`Broker::NetworkInfo`
 
+   Returns a :zeek:see:`Broker::NetworkInfo` record describing the controller.
 
 

--- a/scripts/policy/frameworks/cluster/controller/index.rst
+++ b/scripts/policy/frameworks/cluster/controller/index.rst
@@ -6,28 +6,57 @@ Package: policy/frameworks/cluster/controller
 
 :doc:`/scripts/policy/frameworks/cluster/controller/types.zeek`
 
+   This module holds the basic types needed for the Cluster Controller
+   framework. These are used by both agent and controller, and several
+   have corresponding equals in the zeek-client implementation.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/__load__.zeek`
 
+   The entry point for the cluster controller. It runs bootstrap logic for
+   launching the controller process via Zeek's Supervisor.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/boot.zeek`
 
+   The cluster controller's boot logic runs in Zeek's supervisor and instructs
+   it to launch the controller process. The controller's main logic resides in
+   main.zeek, similarly to other frameworks. The new process will execute that
+   script.
+   
+   If the current process is not the Zeek supervisor, this does nothing.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/config.zeek`
 
+   Configuration settings for the cluster controller.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/api.zeek`
 
+   The event API of cluster controllers. Most endpoints consist of event pairs,
+   where the controller answers a zeek-client request event with a
+   corresponding response event. Such event pairs share the same name prefix
+   and end in "_request" and "_response", respectively.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/log.zeek`
 
+   This module implements straightforward logging abilities for cluster
+   controller and agent. It uses Zeek's logging framework, and works only for
+   nodes managed by the supervisor. In this setting Zeek's logging framework
+   operates locally, i.e., this logging does not involve any logger nodes.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/request.zeek`
 
+   This module implements a request state abstraction that both cluster
+   controller and agent use to tie responses to received request events and be
+   able to time-out such requests.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/util.zeek`
 
+   Utility functions for the cluster controller framework, available to agent
+   and controller.
 
 :doc:`/scripts/policy/frameworks/cluster/controller/main.zeek`
 
+   This is the main "runtime" of the cluster controller. Zeek does not load
+   this directly; rather, the controller's bootstrapping module (in ./boot.zeek)
+   specifies it as the script to run in the node newly created via Zeek's
+   supervisor.
 

--- a/scripts/policy/frameworks/cluster/controller/log.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/log.zeek.rst
@@ -4,6 +4,10 @@ policy/frameworks/cluster/controller/log.zeek
 =============================================
 .. zeek:namespace:: ClusterController::Log
 
+This module implements straightforward logging abilities for cluster
+controller and agent. It uses Zeek's logging framework, and works only for
+nodes managed by the supervisor. In this setting Zeek's logging framework
+operates locally, i.e., this logging does not involve any logger nodes.
 
 :Namespace: ClusterController::Log
 :Imports: :doc:`policy/frameworks/cluster/controller/config.zeek </scripts/policy/frameworks/cluster/controller/config.zeek>`
@@ -12,10 +16,10 @@ Summary
 ~~~~~~~
 Types
 #####
-================================================================================ ====================================================================
-:zeek:type:`ClusterController::Log::Info`: :zeek:type:`record` :zeek:attr:`&log` The record type which contains the column fields of the cluster log.
-:zeek:type:`ClusterController::Log::Level`: :zeek:type:`enum`                    
-================================================================================ ====================================================================
+================================================================================ =========================================================================
+:zeek:type:`ClusterController::Log::Info`: :zeek:type:`record` :zeek:attr:`&log` The record type containing the column fields of the agent/controller log.
+:zeek:type:`ClusterController::Log::Level`: :zeek:type:`enum`                    The controller/agent log supports four different log levels.
+================================================================================ =========================================================================
 
 Redefinitions
 #############
@@ -33,12 +37,12 @@ Hooks
 
 Functions
 #########
-================================================================= =
-:zeek:id:`ClusterController::Log::debug`: :zeek:type:`function`   
-:zeek:id:`ClusterController::Log::error`: :zeek:type:`function`   
-:zeek:id:`ClusterController::Log::info`: :zeek:type:`function`    
-:zeek:id:`ClusterController::Log::warning`: :zeek:type:`function` 
-================================================================= =
+================================================================= ===================================
+:zeek:id:`ClusterController::Log::debug`: :zeek:type:`function`   A debug-level log message writer.
+:zeek:id:`ClusterController::Log::error`: :zeek:type:`function`   An error-level log message writer.
+:zeek:id:`ClusterController::Log::info`: :zeek:type:`function`    An info-level log message writer.
+:zeek:id:`ClusterController::Log::warning`: :zeek:type:`function` A warning-level log message writer.
+================================================================= ===================================
 
 
 Detailed Interface
@@ -46,7 +50,7 @@ Detailed Interface
 Types
 #####
 .. zeek:type:: ClusterController::Log::Info
-   :source-code: policy/frameworks/cluster/controller/log.zeek 20 31
+   :source-code: policy/frameworks/cluster/controller/log.zeek 26 37
 
    :Type: :zeek:type:`record`
 
@@ -66,10 +70,10 @@ Types
          A message indicating information about cluster controller operation.
    :Attributes: :zeek:attr:`&log`
 
-   The record type which contains the column fields of the cluster log.
+   The record type containing the column fields of the agent/controller log.
 
 .. zeek:type:: ClusterController::Log::Level
-   :source-code: policy/frameworks/cluster/controller/log.zeek 12 18
+   :source-code: policy/frameworks/cluster/controller/log.zeek 18 24
 
    :Type: :zeek:type:`enum`
 
@@ -81,11 +85,12 @@ Types
 
       .. zeek:enum:: ClusterController::Log::ERROR ClusterController::Log::Level
 
+   The controller/agent log supports four different log levels.
 
 Hooks
 #####
 .. zeek:id:: ClusterController::Log::log_policy
-   :source-code: policy/frameworks/cluster/controller/log.zeek 10 10
+   :source-code: policy/frameworks/cluster/controller/log.zeek 15 15
 
    :Type: :zeek:type:`Log::PolicyHook`
 
@@ -94,27 +99,48 @@ Hooks
 Functions
 #########
 .. zeek:id:: ClusterController::Log::debug
-   :source-code: policy/frameworks/cluster/controller/log.zeek 56 64
+   :source-code: policy/frameworks/cluster/controller/log.zeek 83 91
 
    :Type: :zeek:type:`function` (message: :zeek:type:`string`) : :zeek:type:`void`
 
+   A debug-level log message writer.
+   
+
+   :message: the message to log.
+   
 
 .. zeek:id:: ClusterController::Log::error
-   :source-code: policy/frameworks/cluster/controller/log.zeek 86 94
+   :source-code: policy/frameworks/cluster/controller/log.zeek 113 121
 
    :Type: :zeek:type:`function` (message: :zeek:type:`string`) : :zeek:type:`void`
 
+   An error-level log message writer. (This only logs a message, it does not
+   terminate Zeek or have other runtime effects.)
+   
+
+   :message: the message to log.
+   
 
 .. zeek:id:: ClusterController::Log::info
-   :source-code: policy/frameworks/cluster/controller/log.zeek 66 74
+   :source-code: policy/frameworks/cluster/controller/log.zeek 93 101
 
    :Type: :zeek:type:`function` (message: :zeek:type:`string`) : :zeek:type:`void`
 
+   An info-level log message writer.
+   
+
+   :message: the message to log.
+   
 
 .. zeek:id:: ClusterController::Log::warning
-   :source-code: policy/frameworks/cluster/controller/log.zeek 76 84
+   :source-code: policy/frameworks/cluster/controller/log.zeek 103 111
 
    :Type: :zeek:type:`function` (message: :zeek:type:`string`) : :zeek:type:`void`
 
+   A warning-level log message writer.
+   
+
+   :message: the message to log.
+   
 
 

--- a/scripts/policy/frameworks/cluster/controller/main.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/main.zeek.rst
@@ -4,6 +4,10 @@ policy/frameworks/cluster/controller/main.zeek
 ==============================================
 .. zeek:namespace:: ClusterController::Runtime
 
+This is the main "runtime" of the cluster controller. Zeek does not load
+this directly; rather, the controller's bootstrapping module (in ./boot.zeek)
+specifies it as the script to run in the node newly created via Zeek's
+supervisor.
 
 :Namespace: ClusterController::Runtime
 :Imports: :doc:`base/frameworks/broker </scripts/base/frameworks/broker/index>`, :doc:`policy/frameworks/cluster/agent/api.zeek </scripts/policy/frameworks/cluster/agent/api.zeek>`, :doc:`policy/frameworks/cluster/agent/config.zeek </scripts/policy/frameworks/cluster/agent/config.zeek>`, :doc:`policy/frameworks/cluster/controller/api.zeek </scripts/policy/frameworks/cluster/controller/api.zeek>`, :doc:`policy/frameworks/cluster/controller/log.zeek </scripts/policy/frameworks/cluster/controller/log.zeek>`, :doc:`policy/frameworks/cluster/controller/request.zeek </scripts/policy/frameworks/cluster/controller/request.zeek>`, :doc:`policy/frameworks/cluster/controller/util.zeek </scripts/policy/frameworks/cluster/controller/util.zeek>`

--- a/scripts/policy/frameworks/cluster/controller/types.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/types.zeek.rst
@@ -4,6 +4,9 @@ policy/frameworks/cluster/controller/types.zeek
 ===============================================
 .. zeek:namespace:: ClusterController::Types
 
+This module holds the basic types needed for the Cluster Controller
+framework. These are used by both agent and controller, and several
+have corresponding equals in the zeek-client implementation.
 
 :Namespace: ClusterController::Types
 
@@ -11,18 +14,18 @@ Summary
 ~~~~~~~
 Types
 #####
-========================================================================= ==========================================================
-:zeek:type:`ClusterController::Types::Configuration`: :zeek:type:`record` 
+========================================================================= ============================================================
+:zeek:type:`ClusterController::Types::Configuration`: :zeek:type:`record` Data structure capturing a cluster's complete configuration.
 :zeek:type:`ClusterController::Types::Instance`: :zeek:type:`record`      Configuration describing a Zeek instance running a Cluster
                                                                           Agent.
 :zeek:type:`ClusterController::Types::InstanceVec`: :zeek:type:`vector`   
 :zeek:type:`ClusterController::Types::Node`: :zeek:type:`record`          Configuration describing a Cluster Node process.
 :zeek:type:`ClusterController::Types::Option`: :zeek:type:`record`        A Zeek-side option with value.
-:zeek:type:`ClusterController::Types::Result`: :zeek:type:`record`        
+:zeek:type:`ClusterController::Types::Result`: :zeek:type:`record`        Return value for request-response API event pairs
 :zeek:type:`ClusterController::Types::ResultVec`: :zeek:type:`vector`     
 :zeek:type:`ClusterController::Types::Role`: :zeek:type:`enum`            Management infrastructure node type.
 :zeek:type:`ClusterController::Types::State`: :zeek:type:`enum`           State that a Cluster Node can be in.
-========================================================================= ==========================================================
+========================================================================= ============================================================
 
 Functions
 #########
@@ -36,11 +39,12 @@ Detailed Interface
 Types
 #####
 .. zeek:type:: ClusterController::Types::Configuration
-   :source-code: policy/frameworks/cluster/controller/types.zeek 60 68
+   :source-code: policy/frameworks/cluster/controller/types.zeek 62 70
 
    :Type: :zeek:type:`record`
 
       id: :zeek:type:`string` :zeek:attr:`&default` = ``fD0qxAnfwOe`` :zeek:attr:`&optional`
+         Unique identifier for a particular configuration
 
       instances: :zeek:type:`set` [:zeek:type:`ClusterController::Types::Instance`] :zeek:attr:`&default` = ``{  }`` :zeek:attr:`&optional`
          The instances in the cluster.
@@ -48,92 +52,115 @@ Types
       nodes: :zeek:type:`set` [:zeek:type:`ClusterController::Types::Node`] :zeek:attr:`&default` = ``{  }`` :zeek:attr:`&optional`
          The set of nodes in the cluster, as distributed over the instances.
 
+   Data structure capturing a cluster's complete configuration.
 
 .. zeek:type:: ClusterController::Types::Instance
-   :source-code: policy/frameworks/cluster/controller/types.zeek 24 31
+   :source-code: policy/frameworks/cluster/controller/types.zeek 26 33
 
    :Type: :zeek:type:`record`
 
       name: :zeek:type:`string`
+         Unique, human-readable instance name
 
       host: :zeek:type:`addr`
+         IP address of system
 
       listen_port: :zeek:type:`port` :zeek:attr:`&optional`
+         Agent listening port. Not needed if agents connect to controller.
 
    Configuration describing a Zeek instance running a Cluster
    Agent. Normally, there'll be one instance per cluster
    system: a single physical system.
 
 .. zeek:type:: ClusterController::Types::InstanceVec
-   :source-code: policy/frameworks/cluster/controller/types.zeek 33 33
+   :source-code: policy/frameworks/cluster/controller/types.zeek 35 35
 
    :Type: :zeek:type:`vector` of :zeek:type:`ClusterController::Types::Instance`
 
 
 .. zeek:type:: ClusterController::Types::Node
-   :source-code: policy/frameworks/cluster/controller/types.zeek 46 57
+   :source-code: policy/frameworks/cluster/controller/types.zeek 48 59
 
    :Type: :zeek:type:`record`
 
       name: :zeek:type:`string`
+         Cluster-unique, human-readable node name
 
       instance: :zeek:type:`string`
+         Name of instance where node is to run
 
       p: :zeek:type:`port`
+         Port on which this node will listen
 
       role: :zeek:type:`Supervisor::ClusterRole`
+         Role of the node.
 
       state: :zeek:type:`ClusterController::Types::State`
+         Desired, or current, run state.
 
       scripts: :zeek:type:`vector` of :zeek:type:`string` :zeek:attr:`&optional`
+         Additional Zeek scripts for node
 
       options: :zeek:type:`set` [:zeek:type:`ClusterController::Types::Option`] :zeek:attr:`&optional`
+         Zeek options for node
 
       interface: :zeek:type:`string` :zeek:attr:`&optional`
+         Interface to sniff
 
       cpu_affinity: :zeek:type:`int` :zeek:attr:`&optional`
+         CPU/core number to pin to
 
       env: :zeek:type:`table` [:zeek:type:`string`] of :zeek:type:`string` :zeek:attr:`&default` = ``{  }`` :zeek:attr:`&optional`
+         Custom environment vars
 
    Configuration describing a Cluster Node process.
 
 .. zeek:type:: ClusterController::Types::Option
-   :source-code: policy/frameworks/cluster/controller/types.zeek 16 19
+   :source-code: policy/frameworks/cluster/controller/types.zeek 18 21
 
    :Type: :zeek:type:`record`
 
       name: :zeek:type:`string`
+         Name of option
 
       value: :zeek:type:`string`
+         Value of option
 
    A Zeek-side option with value.
 
 .. zeek:type:: ClusterController::Types::Result
-   :source-code: policy/frameworks/cluster/controller/types.zeek 71 78
+   :source-code: policy/frameworks/cluster/controller/types.zeek 73 80
 
    :Type: :zeek:type:`record`
 
       reqid: :zeek:type:`string`
+         Request ID of operation this result refers to
 
       instance: :zeek:type:`string` :zeek:attr:`&default` = ``""`` :zeek:attr:`&optional`
+         Name of associated instance (for context)
 
       success: :zeek:type:`bool` :zeek:attr:`&default` = ``T`` :zeek:attr:`&optional`
+         True if successful
 
       data: :zeek:type:`any` :zeek:attr:`&optional`
+         Addl data returned for successful operation
 
       error: :zeek:type:`string` :zeek:attr:`&default` = ``""`` :zeek:attr:`&optional`
+         Descriptive error on failure
 
       node: :zeek:type:`string` :zeek:attr:`&optional`
+         Name of associated node (for context)
 
+   Return value for request-response API event pairs
 
 .. zeek:type:: ClusterController::Types::ResultVec
-   :source-code: policy/frameworks/cluster/controller/types.zeek 80 80
+   :source-code: policy/frameworks/cluster/controller/types.zeek 82 82
 
    :Type: :zeek:type:`vector` of :zeek:type:`ClusterController::Types::Result`
 
 
 .. zeek:type:: ClusterController::Types::Role
-   :source-code: policy/frameworks/cluster/controller/types.zeek 9 14
+   :source-code: policy/frameworks/cluster/controller/types.zeek 11 16
 
    :Type: :zeek:type:`enum`
 
@@ -148,19 +175,29 @@ Types
    continue to be managed by the cluster framework.
 
 .. zeek:type:: ClusterController::Types::State
-   :source-code: policy/frameworks/cluster/controller/types.zeek 37 44
+   :source-code: policy/frameworks/cluster/controller/types.zeek 39 46
 
    :Type: :zeek:type:`enum`
 
       .. zeek:enum:: ClusterController::Types::Running ClusterController::Types::State
 
+         Running and operating normally
+
       .. zeek:enum:: ClusterController::Types::Stopped ClusterController::Types::State
+
+         Explicitly stopped
 
       .. zeek:enum:: ClusterController::Types::Failed ClusterController::Types::State
 
+         Failed to start; and permanently halted
+
       .. zeek:enum:: ClusterController::Types::Crashed ClusterController::Types::State
 
+         Crashed, will be restarted,
+
       .. zeek:enum:: ClusterController::Types::Unknown ClusterController::Types::State
+
+         State not known currently (e.g., because of lost connectivity)
 
    State that a Cluster Node can be in. State changes trigger an
    API notification (see notify_change()).
@@ -168,7 +205,7 @@ Types
 Functions
 #########
 .. zeek:id:: ClusterController::Types::result_to_string
-   :source-code: policy/frameworks/cluster/controller/types.zeek 85 110
+   :source-code: policy/frameworks/cluster/controller/types.zeek 87 112
 
    :Type: :zeek:type:`function` (res: :zeek:type:`ClusterController::Types::Result`) : :zeek:type:`string`
 

--- a/scripts/policy/frameworks/cluster/controller/util.zeek.rst
+++ b/scripts/policy/frameworks/cluster/controller/util.zeek.rst
@@ -4,6 +4,8 @@ policy/frameworks/cluster/controller/util.zeek
 ==============================================
 .. zeek:namespace:: ClusterController::Util
 
+Utility functions for the cluster controller framework, available to agent
+and controller.
 
 :Namespace: ClusterController::Util
 
@@ -11,9 +13,9 @@ Summary
 ~~~~~~~
 Functions
 #########
-======================================================================== =
-:zeek:id:`ClusterController::Util::set_to_vector`: :zeek:type:`function` 
-======================================================================== =
+======================================================================== ============================================================
+:zeek:id:`ClusterController::Util::set_to_vector`: :zeek:type:`function` Renders a set of strings to an alphabetically sorted vector.
+======================================================================== ============================================================
 
 
 Detailed Interface
@@ -21,9 +23,16 @@ Detailed Interface
 Functions
 #########
 .. zeek:id:: ClusterController::Util::set_to_vector
-   :source-code: policy/frameworks/cluster/controller/util.zeek 7 18
+   :source-code: policy/frameworks/cluster/controller/util.zeek 15 26
 
    :Type: :zeek:type:`function` (ss: :zeek:type:`set` [:zeek:type:`string`]) : :zeek:type:`vector` of :zeek:type:`string`
 
+   Renders a set of strings to an alphabetically sorted vector.
+   
+
+   :ss: the string set to convert.
+   
+
+   :returns: the vector of all strings in ss.
 
 


### PR DESCRIPTION
This is the result of a manual `./ci/update-zeekygen-docs.sh` run, to speed things up today.