### PR TITLE
Add note to call out the danger of using "set1 = set1 | set2"

### DIFF
--- a/script-reference/operators.rst
+++ b/script-reference/operators.rst
@@ -154,6 +154,8 @@ Set operators
   * - Set difference
     - ``s1 - s2``
 
+.. _assignment-operators:
+
 Assignment operators
 --------------------
 

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -1063,6 +1063,13 @@ Set operations
 You can compute the union, intersection, or difference of two sets
 using the ``|``, ``&``, and ``-`` operators.
 
+.. note::
+
+   Use ``+=`` instead of ``|`` to grow an existing set. That is,
+   say ``s += new_s`` instead of ``s = s | new_s``. The latter requires
+   copying both input sets and thus quickly deteriorates runtime. See
+   :ref:`assignment-operators` for details.
+
 You can compare sets for equality (they have exactly the same elements)
 using ``==``.  The ``<`` operator returns ``T`` if the lefthand operand
 is a proper subset of the righthand operand.  Similarly, ``<=``


### PR DESCRIPTION
During some performance measurements I compared this to using "add" and noticed
that this quickly gets very slow as set sizes go up (ballpark: OR-ing a
single-member set onto one with 5000 members is well north of a second).