### PR TITLE
Add CI to zeek-docs and bump pygments

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,17 @@
+name: Generate Documentation
+
+on:
+  pull_request
+
+jobs:
+  generate:
+    if: github.repository == 'zeek/zeek-docs'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Fetch Dependencies
+        run: sudo pip3 install -r requirements.txt
+
+      - name: Generate Docs
+        run: make SPHINXOPTS="-W --keep-going"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SPHINXOPTS =
 
 all: html
 
@@ -10,10 +11,10 @@ clean:
 	rm -rf build/html
 
 html: builddir
-	sphinx-build -b html . ./build/html
+	sphinx-build -b html $(SPHINXOPTS) . ./build/html
 
 livehtml: builddir
-	sphinx-autobuild --ignore "*.git/*" --ignore "*.lock" --ignore "*.pyc" --ignore "*.swp" --ignore "*.swpx" --ignore "*.swx" -b html . ./build/html
+	sphinx-autobuild --ignore "*.git/*" --ignore "*.lock" --ignore "*.pyc" --ignore "*.swp" --ignore "*.swpx" --ignore "*.swx" -b html $(SPHINXOPTS) . ./build/html
 
 commit:
 	git add * && git commit -m 'Update generated docs'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Note: beware of https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 # and broken behavior with docutils 0.17
+pygments>=2.12.0
 docutils==0.16
 sphinx_rtd_theme==0.5.2
 Sphinx==3.4.3


### PR DESCRIPTION
The merge of the Management framework docs [broke](https://github.com/zeek/zeek/runs/7165231425?check_suite_focus=true) Zeek's `Generate Docs` job but works in RTD, due to a version mismatch in the pygments highlighter. It'd be nice to get a heads-up of such things prior to merging, so this runs the build via `make` in a Github action triggered on PRs.

The setup is the same as in Zeek (treat warnings as errors), but this uses built-in `sphinx-build` features for this instead of buffering the output and grepping it. If folks like this we could adopt this [in the Zeek action](https://github.com/zeek/zeek/blob/master/.github/workflows/generate-docs.yml#L90-L98) too.

To fix the failure itself, I'm bumping pygments so we test with the same version RTD currently uses.