### PR TITLE
Cover multiple platforms and Python versions in CI, fix macOS build

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -6,12 +6,18 @@ on:
 jobs:
   generate:
     if: github.repository == 'zeek/zeek-docs'
-    runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Fetch Dependencies
         run: sudo pip3 install -r requirements.txt
-
       - name: Generate Docs
         run: make SPHINXOPTS="-W --keep-going"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Note: beware of https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
 # and broken behavior with docutils 0.17
+jinja2<3.1
 pygments>=2.12.0
 docutils==0.16
 sphinx_rtd_theme==0.5.2


### PR DESCRIPTION
Turns out it was broken there, as @timwoj noticed.

Resolves #123.