### PR TITLE
install: Add libfl-dev to Ubuntu/Debian requirements

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -165,7 +165,7 @@ To install these, you can use:
 
   .. code-block:: console
 
-     sudo apt-get install cmake make gcc g++ flex bison libpcap-dev libssl-dev python3 python3-dev swig zlib1g-dev
+     sudo apt-get install cmake make gcc g++ flex libfl-dev bison libpcap-dev libssl-dev python3 python3-dev swig zlib1g-dev
 
 * FreeBSD:
 


### PR DESCRIPTION
Spicy, which is built by default with Zeek, requires libfl-dev. Mention it as dependency explicitly.

Closes zeek/zeek#2421