### PR TITLE
Suggest installing recommended packages for container image.

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -52,7 +52,7 @@ analyzer packages.
   .. code-block:: console
 
     apt-get update
-    apt-get install -y --no-install-recommends g++ cmake make libpcap-dev
+    apt-get install -y g++ cmake make libpcap-dev
 
 The Dockerfile lives `here <https://github.com/zeek/zeek/blob/master/docker/Dockerfile>`_.
 


### PR DESCRIPTION
When documenting additional packages needed to get Spicy running in our container image, we recommended a command line which used `--no-install-recommends`. This command line doesn't seem to work as some recommended depedency does not get installed.

With this patch we now do not document skipping recommended packages anymore.