### PR TITLE
broker: Proxies aren't actually optional

### DIFF
--- a/frameworks/broker.rst
+++ b/frameworks/broker.rst
@@ -39,9 +39,6 @@ variable :zeek:see:`Cluster::NodeType`.
 - Worker
 - Proxy
 
-Proxy nodes are optional with Zeek's base scripts. However, certain external or
-third-party scripts may require the presence of proxies in a cluster.
-
 In small Zeek deployments, all nodes may run on a single host. In large
 Zeek deployments, nodes may be distributed across multiple physical
 systems for scaling.


### PR DESCRIPTION
Skimming the base scripts for proxy_topic or proxy_pool, it seems specifically base/frameworks/software uses proxy_pool unconditionally without a fallback.

I introduced that sentence recently, I'm not sure if I had picked that up elsewhere, or just assumed because mostly things work without proxies and there's no warning or so (which maybe we should add).