### PR TITLE
Update binary package details to reflect new version labeling

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -20,8 +20,10 @@ Installing Zeek
 ===============
 
 To run Zeek, grab our official Docker images, download our Linux binary
-packages, install via Homebrew on your Mac, use the ports collections on
-FreeBSD and OpenBSD, or build Zeek yourself.
+packages, install via Homebrew on your Mac, use the ports collections on FreeBSD
+and OpenBSD, or build Zeek yourself. For details about our release cadence
+and the significance of Zeek's version numbers, please refer to our `Release
+Cadence <https://github.com/zeek/zeek/wiki/Release-Cadence>`_ wiki page.
 
 Docker Images
 =============
@@ -30,7 +32,8 @@ We provide official Docker images on Docker Hub at https://hub.docker.com/u/zeek
 
     * For the latest feature release: ``docker pull zeek/zeek:latest``
     * For the latest LTS release: ``docker pull zeek/zeek:lts``
-    * For a specific release: ``docker pull zeek/zeek:5.0.0-rc1``
+    * For the latest release in a given series: ``docker pull zeek/zeek:5.2``
+    * For a specific release: ``docker pull zeek/zeek:6.0.0``
     * For the nightly build: ``docker pull zeek/zeek-dev:latest``
 
 Additionally, we push these images to Amazon's Public Elastic Container
@@ -69,21 +72,34 @@ for a wide range of Linux distributions via the `openSUSE Build Service
 package repository to your system, then use your system's package manager
 as usual.
 
-We provide packages for:
+We provide the following groups of packages:
 
-    * the `latest Zeek feature release <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek>`__)
-    * the `latest Zeek LTS release <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-lts>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-lts>`__)
-    * `nightly builds <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-nightly>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-nightly>`__)
-    * `release candidates <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-rc>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-rc>`__)
+    * ``zeek-X.0``: specific LTS release lines, currently `5.0.x <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-5.0>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-5.0>`__) and `6.0.x <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-6.0>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-6.0>`__)
+    * ``zeek``: the `latest Zeek release <https://software.opensuse.org//download.html?project=security%3Azeek&package=zeek>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek>`__)
+    * ``zeek-nightly``: our `nightly builds <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-nightly>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-nightly>`__)
+    * ``zeek-rc``: our `release candidates <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-rc>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-rc>`__)
 
-For example, for the Zeek LTS release on Ubuntu 22.04 the steps look as follows:
+For example, for the latest Zeek 6.0 LTS release on Ubuntu 22.04 the steps look as follows:
 
   .. code-block:: console
 
      echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_22.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
      curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
      sudo apt update
-     sudo apt install zeek-lts
+     sudo apt install zeek-6.0
+
+.. note:: Our motivation for this approach is twofold. First, it guarantees LTS
+   users that they won't unexpectedly end up on a newer LTS line when it comes
+   out. For example, when you install the ``zeek-6.0`` packages, you will not
+   end up on Zeek 7.0 until you decide to switch. Second, it reflects the fact
+   that we consider our x.1 and x.2 feature release lines transient, because
+   they go out of support immediately once we move to the next line of feature
+   releases. Therefore, users of the ``zeek`` packages automatically obtain the
+   latest releases as we publish them.
+   
+   In the past our binary packages also automatically transitioned our LTS users
+   to newer versions, via the older ``zeek-lts`` packages. These remain visible
+   on OBS but are no longer supported.
 
 The primary install prefix for binary packages is :file:`/opt/zeek` (depending
 on which version you’re using), and includes a complete Zeek environment with

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Pygments>=2.12.0
 docutils==0.17.1
 sphinx_rtd_theme==1.2.0
 Sphinx==5.3.0
-GitPython==3.1.34
+GitPython==3.1.35


### PR DESCRIPTION
This covers the change in OBS package naming to no longer provide packages abstractly named "zeek" and "zeek-lts", and instead shift to ones named after release trains such as "zeek-6.0".