### PR TITLE
conf: Add sphinx_rtd_theme to extensions, remove env based import

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -141,15 +141,7 @@ highlight_language = 'none'
 
 # -- Options for HTML output ---------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:
-    # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'sphinx_rtd_theme'
 
 html_last_updated_fmt = '%B %d, %Y'
 


### PR DESCRIPTION
The RTD build failed with "NameError: name 'html_theme' is not defined".

Remove the conditional import and align to what Spicy and the sphinx_rtd_theme docs [1] indicate should be done.

[1] https://sphinx-rtd-theme.readthedocs.io/en/stable/installing.html

RTD build: https://readthedocs.org/projects/zeek-docs/builds/21704944/