### PR TITLE
Fix Github edit links in top-right of HTML pages

### DIFF
--- a/_templates/breadcrumbs.html
+++ b/_templates/breadcrumbs.html
@@ -5,7 +5,7 @@
 {% if pagename != "search" %}
   {% if display_github %}
     {% if github_version == "master" %}
-      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+      <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
     {% endif %}
   {% elif show_source and has_source and sourcename %}
     <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> {{ _('View page source') }}</a>


### PR DESCRIPTION
Matti noticed that these links 404'd because they omitted the file suffix. This change uses a different variable name in Jinja to fix that, and also changes the target link to the editable sources instead the default source viewer.

There's an LTD test build here if you want to check it out: https://docs.zeek.org/en/topic-christian-test-fix-github-edit-link/

Once this goes in we need it twice more, for the Broker and zkg docs.