### PR TITLE
management/full-config: no toml highlighting

### DIFF
--- a/frameworks/management.rst
+++ b/frameworks/management.rst
@@ -606,11 +606,7 @@ Here's a full-featured configuration describing the available options, assuming
 a single agent running on a machine "testbox" with default settings:
 
 .. literalinclude:: management/full-config.ini
-   :language: toml
-..
-   Using toml in the above only because it produces slightly better highlighting.
-   The files are not technically TOML but what's compatible with Python's
-   configparser classes.
+   :language: ini
 
 .. _simplification-instance-local:
 


### PR DESCRIPTION
With Pygments 2.17, the TOML parser was rewritten[1, 2]. It now fails to parse and highlight the `full-config.ini` file. The key-only `agent-testbox` within `[instances]` makes the standard toml parsing barf, too. Flip to ini.

[1] https://pygments.org/docs/changelog/#version-2-17-0
[2] https://github.com/pygments/pygments/pull/2576