### PR TITLE
Reduce some details in the `table[pattern]` usage note

### DIFF
--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -1161,17 +1161,16 @@ as ``/.*foo.*/``.
 
 .. note::
 
-   Internally, the individual patterns are matched in parallel using a lazily
-   constructed determinstic finite automaton (DFA). Depending on the nature of
-   patterns used within the table *and* the input data used for lookups, this
-   may result in difficult to predict memory consumption over time.
+   Internally, Zeek matches a table's patterns in parallel using a lazily
+   constructed deterministic finite automaton (DFA). This means that the nature
+   of patterns in the table *and* the strings looked up in it can lead to
+   varying degrees of runtime memory growth.
 
-   Users are advised to test scripts using this feature with realistic and
-   adversarial input data with focus on memory growth. It is possible to
-   reset the DFA's state by removal or addition of a single pattern. For
-   observability, the function :zeek:see:`table_pattern_matcher_stats` can
-   be used. It returns a :zeek:see:`MatcherStats` record with details about
-   the DFA's state.
+   Users are advised to test scripts using this feature with a wide range of
+   input data. Script developers can reset the DFA's state by removal or
+   addition of a single pattern. For observability, the
+   :zeek:see:`table_pattern_matcher_stats` function returns a
+   :zeek:see:`MatcherStats` record with details about a table's DFA state.
 
 
 Additional operations

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -733,7 +733,7 @@ Additional examples:
 - ``/foo|bar/i`` matches ``"foo"``, ``"Foo"``, ``"BaR"``, etc.
 - ``/foo|(?i:bar)/`` matches ``"foo"`` and ``"BaR"``, but *not* ``"Foo"``.
 - ``/"foo"/i`` matches ``"foo"``, but *not* ``"Foo"``.
-- ``/foo.bar/`` doesn't matche ``"foo\nbar"``, while ``/foo.bar/s`` does.
+- ``/foo.bar/`` doesn't match ``"foo\nbar"``, while ``/foo.bar/s`` does.
 
 The ``i`` and ``s`` modifiers can also be combined in a single pattern
 such as ``/foo/is`` or ``/bar/si``. In this case, both case-insensitivity


### PR DESCRIPTION
This is quite nit-picky, forgive me — but it tones down the details a bit because I don't think it's clear to most users how one would actually construct an adversarial set of inputs to a given table. (We could explain that too, though I'm thinking that's not really necessary here.)