### PR TITLE
Point to conan 1.58.0 in Windows instructions

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -256,7 +256,7 @@ To install these, you can use:
 
      choco install -y --no-progress visualstudio2019buildtools --version=16.11.11.0
      choco install -y --no-progress visualstudio2019-workload-vctools --version=1.0.0 --package-parameters '--add Microsoft.VisualStudio.Component.VC.ATLMFC'
-     choco install -y --no-progress conan
+     choco install -y --no-progress conan --version=1.58.0
      choco install -y --no-progress sed
      choco install -y --no-progress winflexbison3
      choco install -y --no-progress msysgit


### PR DESCRIPTION
When revisiting the Windows compilation instructions recently, I briefly got hung up with a `conan`-related failure. I confirmed by reviewing the CI code at https://github.com/zeek/zeek/blob/7a9a40f822ee01cc65b8e9377c4fa087a57b2dc2/ci/windows/Dockerfile#L19C10-L19C10 that it's important to pin the `conan` version for now, so proposing to sync the docs with that. @timwoj confirmed in a [Slack thread](https://zeekorg.slack.com/archives/C04H7FMASUQ/p1703386260172159?thread_ts=1703298555.115639&cid=C04H7FMASUQ) that this docs change is probably worth making.