### PR TITLE
Point to openssl 3.1.1 in Windows instructions

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -265,7 +265,7 @@ To install these, you can use:
      choco install -y --no-progress winflexbison3
      choco install -y --no-progress msysgit
      choco install -y --no-progress python
-     choco install -y --no-progress openssl
+     choco install -y --no-progress openssl --version=3.1.1
 
   Once the dependencies are installed, you will need to add the Git installation
   to your PATH (``C:\Program Files\Git\bin`` by default). This is needed for the


### PR DESCRIPTION
I was rebuilding Zeek on Windows to reproduce a problem and ended up bumping into the same problem described in https://github.com/zeek/zeek/pull/3587. I propose updating the user-facing docs so others don't get similarly thrown by this.