### PR TITLE
CI: Remove Python 3.7, add Python 3.12

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.7 builds aren't available on macOS ARM anymore, so CI builds will always fail. Also, Python 3.12 has come out. Python 3.13 is available but it's still only alpha builds so we can hold off on that for now.