### PR TITLE
Fix a couple Spicy doc nits

### DIFF
--- a/devel/spicy/examples/tftp-schedule-analyzer.zeek
+++ b/devel/spicy/examples/tftp-schedule-analyzer.zeek
@@ -1,37 +1,37 @@
 
-function schedule_tftp_analyzer(id: conn_id) 
-	{
-	# Schedule the TFTP analyzer for the expected next packet coming in on different 
-        # ports. We know that it will be exchanged between same IPs and reuse the 
-        # originator's port. "Spicy_TFTP" is the Zeek-side name of the TFTP analyzer 
-        # (generated from "Spicy::TFTP" in tftp.evt).
-	Analyzer::schedule_analyzer(id$resp_h, id$orig_h, id$orig_p, Analyzer::get_tag("Spicy_TFTP"), 1min);
-	}
+function schedule_tftp_analyzer(id: conn_id)
+    {
+    # Schedule the TFTP analyzer for the expected next packet coming in on different
+    # ports. We know that it will be exchanged between same IPs and reuse the
+    # originator's port. "Spicy_TFTP" is the Zeek-side name of the TFTP analyzer
+    # (generated from "Spicy::TFTP" in tftp.evt).
+    Analyzer::schedule_analyzer(id$resp_h, id$orig_h, id$orig_p, Analyzer::ANALYZER_SPICY_TFTP, 1min);
+    }
 
-event tftp::read_request(c: connection, is_orig: bool, filename: string, mode: string) 
-	{
-	print "TFTP read request", c$id, filename, mode;
-	schedule_tftp_analyzer(c$id);
-	}
+event tftp::read_request(c: connection, is_orig: bool, filename: string, mode: string)
+    {
+    print "TFTP read request", c$id, filename, mode;
+    schedule_tftp_analyzer(c$id);
+    }
 
 event tftp::write_request(c: connection, is_orig: bool, filename: string, mode: string)
-	{
-	print "TFTP write request", c$id, filename, mode;
-	schedule_tftp_analyzer(c$id);
-	}
+    {
+    print "TFTP write request", c$id, filename, mode;
+    schedule_tftp_analyzer(c$id);
+    }
 
 # Add handlers for other packet types so that we see their events being generated.
 event tftp::data(c: connection, is_orig: bool, block_num: count, data: string)
-	{
-	print "TFTP data", block_num, data;
-	}
+    {
+    print "TFTP data", block_num, data;
+    }
 
 event tftp::ack(c: connection, is_orig: bool, block_num: count)
-	{
-	print "TFTP ack", block_num;
-	}
+    {
+    print "TFTP ack", block_num;
+    }
 
 event tftp::error(c: connection, is_orig: bool, code: count, msg: string)
-	{
-	print "TFTP error", code, msg;
-	}
+    {
+    print "TFTP error", code, msg;
+    }

--- a/devel/spicy/reference.rst
+++ b/devel/spicy/reference.rst
@@ -115,7 +115,7 @@ properties are supported:
 
             .. _zeek_init_instead_of_port:
 
-            While using ``port`` (or ``%port``) can be convinient, for
+            While using ``port`` (or ``%port``) can be convenient, for
             production analyzers we recommended to instead register
             their well-known ports from inside a Zeek script, using a
             snippet like this:


### PR DESCRIPTION
- convenient was misspelled
- Spicy TFTP example needs [another](https://github.com/zeek/zeek-docs/pull/275) pass, apparently there's another script that is roughly similar that still used `get_tag` :)
- Fixed up some whitespace stuff in that TFTP example - that file mixed tabs and 8 spaces so I just moved it to 4 spaces.

Fun fact: building docs fresh was fine, but when I pulled main and rebuilt it, it crashed my laptop and tried to crash it again when I retried. Like 7 python processes each taking 3GB :O