### PR TITLE
Fix installation of Python packages in generate docs CI job

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Fetch Dependencies
-        run: sudo pip3 install -r requirements.txt
+        run: sudo pip3 install --break-system-packages -r requirements.txt
       - name: Generate Docs
         run: make SPHINXOPTS="-W --keep-going"

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -13,8 +13,8 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Fetch Dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2==3.1.4
-Pygments>=2.12.0
+Pygments==2.17.2
 docutils==0.17.1
 sphinx_rtd_theme==2.0.0
 Sphinx==5.3.0


### PR DESCRIPTION
This job uses `ubuntu-latest`, i.e., it will automatically use the
newest version of Ubuntu available. On current versions `pip install`
refuses to install packages into the system since this might break
system packages. Users are expected to explicitly opt into this
potential breakage by passing the `--break-system-packages` flag. This
is an acceptable workaround here since we do not distribute this setup,
and currently things appear to not break.