### PR TITLE
Fix installation of Python packages in generate docs CI job again

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -9,8 +9,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os:
+          - 'ubuntu-22.04'
+          - 'macos-latest'
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +25,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Fetch Dependencies
-        run: sudo pip3 install --break-system-packages -r requirements.txt
+        run: pip3 install -r requirements.txt
       - name: Generate Docs
         run: make SPHINXOPTS="-W --keep-going"


### PR DESCRIPTION
This pins the generate-docs GH workflow to run on a fixed version of ubuntu so we get defined semantics of pip install wrt system packages. We were previously using the ubuntu-latest image and GH has been switching this from ubuntu-22.04 to 24.04 and back again, also see actions/runner-images#10636.