### PR TITLE
generate-docs: Use ubuntu-latest

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - 'ubuntu-22.04'
+          - 'ubuntu-latest'
           - 'macos-latest'
         python-version:
           - '3.8'


### PR DESCRIPTION
Commit https://github.com/zeek/zeek-docs/commit/bd300424466d4939ef8e2eaa9936a09cbd59f1f5 removed the sudo usage
which was the actual culprit for using the wrong pip version. Bump up
to ubuntu-latest again.