### PR TITLE
Cleanup `for` loop example + bump stated Python version

### DIFF
--- a/README
+++ b/README
@@ -75,7 +75,7 @@ Local Previewing (How To Build)
 
 First make sure you have the required dependencies used for building docs:
 
-* Python interpreter >= 3.7
+* Python interpreter >= 3.9
 * Sphinx: https://www.sphinx-doc.org/en/master/
 * Read the Docs Sphinx Theme: https://github.com/rtfd/sphinx_rtd_theme
 * GitPython: https://github.com/gitpython-developers/GitPython

--- a/install.rst
+++ b/install.rst
@@ -175,7 +175,7 @@ development headers for libraries:
     * Libpcap (http://www.tcpdump.org)
     * Make
     * OpenSSL (http://www.openssl.org)
-    * Python 3.7 or greater (https://www.python.org/)
+    * Python 3.9 or greater (https://www.python.org/)
     * SWIG (http://www.swig.org)
     * Zlib (https://zlib.net/)
 

--- a/script-reference/statements.rst
+++ b/script-reference/statements.rst
@@ -718,29 +718,29 @@ Example:
 .. code-block:: zeek
 
     local myset = set(80/tcp, 81/tcp);
-    local mytable = table([10.0.0.1, 80/tcp]="s1", [10.0.0.2, 81/tcp]="s2");
-    local myvector = vector("zero", "one, "two");
+    local mytable = table([ 10.0.0.1, 80/tcp ] = "s1", [ 10.0.0.2, 81/tcp ] = "s2");
+    local myvector = vector("zero", "one", "two");
 
     for ( p in myset )
         print p;
 
-    for ( [i,j], val in mytable )
+    for ( [ip, p], val in mytable )
         {
-        if (val == "done")
+        if ( val == "done" )
             break;
-        if (val == "skip")
+        if ( val == "skip" )
             next;
-        print i,j;
+        print ip, p;
         }
 
     for ( _, val in mytable )
         print val;
 
-    for ( [i,_], _ in mytable )
-        print i;
+    for ( [ip, _], _ in mytable )
+        print ip;
 
     for ( i, val in myvector )
-        print i,val;
+        print i, val;
 
     for ( _, val in myvector )
         print val;


### PR DESCRIPTION
Gets that example to ~compile~ run. Also bumps the stated Python version to 3.9 (after #285)