### PR TITLE
Remove copyright year

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -49,7 +49,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Zeek"
-copyright = "2019-2023, The Zeek Project"
+copyright = "by the Zeek Project"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
related https://github.com/zeek/zeek/pull/4161

"by the Zeek Project" looks better to me than "The Zeek Project" and that's what Spicy docs use

![Screenshot 2025-01-09 at 11 15 57 AM](https://github.com/user-attachments/assets/28d87d26-36ec-42d1-b996-43933287f8d7)
