### PR TITLE
Add sphinx configuration key for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,3 +11,6 @@ build:
 python:
   install:
     - requirements: requirements.txt
+
+sphinx:
+  configuration: conf.py


### PR DESCRIPTION
RTD started enforcing the existence of this key in their yml file as of 2025/01/20. See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/ for more info. https://readthedocs.org/projects/zeek-docs/builds/26952573/ is a build that includes the config option for testing.

Our master builds are currently failing due to the lack of this key.