### PR TITLE
updating to OpenBSD port

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -140,7 +140,7 @@ These packages are not maintained by the Zeek project.
 OpenBSD
 -------
 
-Zeek is available from the `OpenBSD ports collection <https://openports.se/net/bro>`_.
+Zeek is available from the `OpenBSD ports collection <https://ports.to/path/net/bro.html>`_.
 To install:
 
   .. code-block:: console


### PR DESCRIPTION
The install documentation references an outdated website for the OpenBSD package of zeek.

https://github.com/zeek/zeek-docs/blob/78bb7c7005a59d865540c8e1189aa0637894a627/install.rst?plain=1#L143

The referenced website has been repurposed.
Ive changed the link to another site showing OpenBSD package information.

