### PR TITLE
Link Spicy in subcomponent documentation

### DIFF
--- a/components/index.rst
+++ b/components/index.rst
@@ -6,6 +6,8 @@ Subcomponents
 To find documentation for the various subcomponents of Zeek, see their
 respective GitHub repositories or documentation:
 
+* `Spicy <https://docs.zeek.org/projects/spicy>`__
+  - C++ parser generator for dissecting protocols & files.
 * `BinPAC <https://github.com/zeek/binpac>`__
   - A protocol parser generator
 * `ZeekControl <https://github.com/zeek/zeekctl>`__


### PR DESCRIPTION
It is probably worth it to directly link Spicy in the Zeek docs. In this patch I inserted a link above the link to binpac since today we would prefer users looking into Spicy instead binpac, but other than that I have no strong opinion on the exact order.