### PR TITLE
Add typos pre-commit rule, fix findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,8 @@ repos:
   - id: rst-backticks
     stages: ["pre-commit"]
     exclude: 'scripts/builtin-plugins/Zeek_JavaScript/__load__.zeek.rst'
+
+- repo: https://github.com/crate-ci/typos
+  rev: v1.30.1
+  hooks:
+    - id: typos

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,60 @@
+[default]
+extend-ignore-re = [
+    # seh too close to she
+    "registered SEH to support IDL",
+    # ALLO is a valid FTP command
+    "\"ALLO\".*[0-9]{3}",
+    "des-ede3-cbc-Env-OID",
+    # On purpose
+    "\"THE NETBIOS NAM\"",
+    # NFS stuff.
+    "commited: :zeek:type:`NFS3::stable_how_t`",
+    "\\/fo\\(o",
+    "  nd\\.<br",
+    "\"BaR\"",
+    "Not-ECT",
+    "Ninteenth: Ninteenth",
+
+    # Connecton and file UIDs
+    "[CF][a-zA-Z0-9]{17}",
+
+    # Smoot
+    "Smoot",
+]
+
+extend-ignore-identifiers-re = [
+    "TLS_.*_EDE.*_.*",
+    "SSL.*_EDE.*_.*",
+    "_3DES_EDE_CBC_SHA",
+    "GOST_R_.*",
+    "icmp6_nd_.*",
+    "pn", # Use for `PoolNode` variables
+    "complte_flag", # Existing use in exported record in base.
+    "VidP(n|N)", # In SMB.
+    "iin", # In DNP3.
+    "(ScValidatePnPService|ScSendPnPMessage)", # In DCE-RPC.
+    "snet", # Used as shorthand for subnet in base scripts.
+    "typ",
+]
+
+[default.extend-identifiers]
+MCA_OCCURED = "MCA_OCCURED"
+MNT3ERR_ACCES = "MNT3ERR_ACCES"
+ND_QUEUE_OVERFLOW = "ND_QUEUE_OVERFLOW"
+ND_REDIRECT = "ND_REDIRECT"
+NFS3ERR_ACCES = "NFS3ERR_ACCES"
+NO_SEH = "NO_SEH"
+RPC_NT_CALL_FAILED_DNE = "RPC_NT_CALL_FAILED_DNE"
+RpcAddPrintProvidor = "RpcAddPrintProvidor"
+RpcDeletePrintProvidor = "RpcDeletePrintProvidor"
+THA = "THA"
+tha = "tha"
+uses_seh = "uses_seh"
+
+[default.extend-words]
+caf = "caf"
+helo = "helo"
+# Seems we use this in the management framework
+requestor = "requestor"
+# `inout` is used as a keyword in Spicy, but looks like a typo of `input`.
+inout = "inout"

--- a/cluster-setup.rst
+++ b/cluster-setup.rst
@@ -494,7 +494,7 @@ and user-space DNA (Direct NIC Access) for fast packet capture/transmission.
 .. note::
 
    Unless you have evaluated to specifically require PF_RING, consider using
-   AF_PACKET first and test if it fullfills your requirements. AF_PACKET has
+   AF_PACKET first and test if it fulfills your requirements. AF_PACKET has
    been integrated into Zeek since version 5.2. It's a bit easier to get
    started with as it does not require an out of tree Linux kernel module.
 

--- a/devel/spicy/index.rst
+++ b/devel/spicy/index.rst
@@ -45,7 +45,7 @@ finger;``.
 
 .. note::
 
-   This documentation focusses on writing *external* Spicy analyzers
+   This documentation focuses on writing *external* Spicy analyzers
    that you can load into Zeek at startup. Zeek also comes with the
    infrastructure to build Spicy analyzers directly into the
    executable itself, just like traditional built-in analyzers. We

--- a/frameworks/management.rst
+++ b/frameworks/management.rst
@@ -491,7 +491,7 @@ Compatibility
 Zeek 5.2 switched client/controller communication from Broker's native wire
 format to the newer `WebSocket data transport
 <https://docs.zeek.org/projects/broker/en/current/web-socket.html>`_, with
-``zeek-client`` 1.2.0 being the first version to exlusively use WebSockets.
+``zeek-client`` 1.2.0 being the first version to exclusively use WebSockets.
 This has a few implications:
 
 * Since Broker dedicates separate ports to the respective wire formats, the
@@ -659,7 +659,7 @@ Configuration of the Telemetry framework
 ----------------------------------------
 
 By default, the framework will enable Prometheus metrics exposition ports,
-including a service discovery endpoint on the mananger (refer to the
+including a service discovery endpoint on the manager (refer to the
 :ref:`Telemetry Framework <framework-telemetry>` for details), and
 auto-assign them for you. Specifically, the controller will enumerate ports
 starting from

--- a/install.rst
+++ b/install.rst
@@ -294,7 +294,7 @@ To install these, you can use:
   Note: By default, Windows links against the standard libpcap library from
   vcpkg. This version of libpcap does not support packet capture on Windows,
   unlike other platforms. In order to capture packets from live interfaces on
-  Windows, you will need to link against the Npcap_ libary. This library is free
+  Windows, you will need to link against the Npcap_ library. This library is free
   for personal use, but requires a paid license for commercial use or
   redistribution. To link against Npcap, download the SDK from their website,
   unzip it, and then pass ``-DPCAP_ROOT_DIR="<path to npcap sdk>"`` to the

--- a/script-reference/operators.rst
+++ b/script-reference/operators.rst
@@ -202,7 +202,7 @@ For :zeek:type:`table` and :zeek:type:`set` values,
 each of the RHS elements are added to the
 table or set.  For :zeek:type:`vector`, the RHS elements are appended to
 the end of the vector.  For :zeek:type:`pattern` values, the pattern is
-modified to include the RHS pattern as an alterantive (regular expression ``|``
+modified to include the RHS pattern as an alternative (regular expression ``|``
 operator).
 
 The ``-=`` operator provides analogous functionality for :zeek:type:`table`

--- a/script-reference/statements.rst
+++ b/script-reference/statements.rst
@@ -308,7 +308,7 @@ the ``&log`` attribute.
 .. note::
 
    The :ref:`logging framework <framework-logging>` provides a separate
-   mechanism to exlude columns from logs by means of the ``exclude`` field
+   mechanism to exclude columns from logs by means of the ``exclude`` field
    on :zeek:see:`Log::Filter` instances.
 
 Examples:

--- a/troubleshooting.rst
+++ b/troubleshooting.rst
@@ -53,7 +53,7 @@ has it enabled while Fedora 38 does not. You're advised to verify the
 
 You can either build Zeek from source and pass the ``--enable-jemalloc`` flag
 (possibly with ``--with-jemalloc=/usr/local/`` for a custom build) to always
-use the jemalloc allocater (recommended), or set ``LD_PRELOAD`` as shown above.
+use the jemalloc allocator (recommended), or set ``LD_PRELOAD`` as shown above.
 Using ``LD_PRELOAD`` can be convenient if you're not
 in a position to rebuild Zeek or you're consuming upstream binary packages that
 did not use ``--enable-jemalloc``, or you want to use a custom ad-hoc/patched
@@ -381,7 +381,7 @@ The following provides an example of :file:`prof.log` content:
    1684828262.344351 TCP-States:Rst.                                    16      64              
    1684828262.344351 Connections expired due to inactivity: 2426
    1684828262.344351 Timers: current=47708 max=47896 lag=0.00s
-   1684828262.344351 DNS_Mgr: requests=1596 succesful=1596 failed=0 pending=0 cached_hosts=0 cached_addrs=1207
+   1684828262.344351 DNS_Mgr: requests=1596 successful=1596 failed=0 pending=0 cached_hosts=0 cached_addrs=1207
    1684828262.344351 Triggers: total=4900 pending=0
    1684828262.344351         ConnectionDeleteTimer = 905
    1684828262.344351         ConnectionInactivityTimer = 6759


### PR DESCRIPTION
This ended up not being as wild as I expected. It uses a modified version of the typos.toml file from zeek/zeek. A bunch of rules from there don't matter here (such as all of the script_opt `ot` ones). There are a few new rules, but nothing wild:

- Ignore `Ninteenth`, `fo(o`, `Not-ECT`, Connection and file IDs, and a couple of strings from hexdumps in some of the logs.
- Keep it from changing "Smoot" to "Smooth"

Fixes #305 