### PR TITLE
Touchup install and quickstart

### DIFF
--- a/get-started/install.rst
+++ b/get-started/install.rst
@@ -24,8 +24,8 @@ We provide official Docker images on Docker Hub at https://hub.docker.com/u/zeek
 
     * For the latest feature release: ``docker pull zeek/zeek:latest``
     * For the latest LTS release: ``docker pull zeek/zeek:lts``
-    * For the latest release in a given series: ``docker pull zeek/zeek:5.2``
-    * For a specific release: ``docker pull zeek/zeek:6.0.0``
+    * For the latest release in a given series: ``docker pull zeek/zeek:7.2``
+    * For a specific release: ``docker pull zeek/zeek:7.0.8``
     * For the nightly build: ``docker pull zeek/zeek-dev:latest``
 
 Additionally, we push these images to Amazon's Public Elastic Container
@@ -68,19 +68,19 @@ as usual.
 
 We provide the following groups of packages:
 
-    * ``zeek-X.0``: specific LTS release lines, currently `5.0.x <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-5.0>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-5.0>`__) and `6.0.x <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-6.0>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-6.0>`__)
+    * ``zeek-X.0``: specific LTS release lines, currently `7.0.x <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-7.0>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-7.0>`__), `6.0.x <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-6.0>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-6.0>`__), and `5.0.x <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-5.0>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-5.0>`__).
     * ``zeek``: the `latest Zeek release <https://software.opensuse.org//download.html?project=security%3Azeek&package=zeek>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek>`__)
     * ``zeek-nightly``: our `nightly builds <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-nightly>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-nightly>`__)
     * ``zeek-rc``: our `release candidates <https://software.opensuse.org/download.html?project=security%3Azeek&package=zeek-rc>`_ (`sources <https://build.opensuse.org/package/show/security:zeek/zeek-rc>`__)
 
-For example, for the latest Zeek 6.0 LTS release on Ubuntu 22.04 the steps look as follows:
+For example, for the latest Zeek 7.0 LTS release on Ubuntu 22.04 the steps look as follows:
 
   .. code-block:: console
 
      echo 'deb https://download.opensuse.org/repositories/security:/zeek/xUbuntu_22.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list
      curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null
      sudo apt update
-     sudo apt install zeek-6.0
+     sudo apt install zeek-7.0
 
 .. note:: Our motivation for this approach is twofold. First, it guarantees LTS
    users that they won't unexpectedly end up on a newer LTS line when it comes

--- a/get-started/quickstart.rst
+++ b/get-started/quickstart.rst
@@ -124,6 +124,9 @@ want to monitor traffic on):
 
      $ zeek -i en0 -C
 
+Root access is typically required to run commands which monitor a network
+device.
+
 In another terminal, create the same two HTTP requests we saw earlier via
 ``curl``:
 
@@ -249,7 +252,6 @@ Then return to the ZeekControl prompt and stop it:
 
      [ZeekControl] > stop
      stopping zeek ...
-     [ZeekControl] > exit
 
 And exit from ``zeekctl``:
 


### PR DESCRIPTION
Just a couple things I noticed. The install section should probably default to showing newer releases first IMO

Random point, I waffled on the wording for this, any other suggestions? I just realized I have to use `sudo` but never mention it:

> Commands which use a network device require root access in order to monitor traffic.