### PR TITLE
Improve event group example code

### DIFF
--- a/scripting/event_groups_attr_02.zeek
+++ b/scripting/event_groups_attr_02.zeek
@@ -42,5 +42,5 @@ event zeek_init()
     });
 
     # Trigger the change handler, once.
-    Config::set_value("Debug::http_print_debugging", F);
+    Config::set_value("Debug::http_print_debugging", http_print_debugging);
     }

--- a/scripting/event_groups_module_01.zeek
+++ b/scripting/event_groups_module_01.zeek
@@ -42,6 +42,6 @@ event zeek_init()
     Option::set_change_handler("Packages::community_id_enabled", package_change_handler);
     Option::set_change_handler("Packages::ja3_enabled", package_change_handler);
 
-    Config::set_value("Packages::community_id_enabled", F);
-    Config::set_value("Packages::ja3_enabled", F);
+    Config::set_value("Packages::community_id_enabled", community_id_enabled);
+    Config::set_value("Packages::ja3_enabled", ja3_enabled);
     }


### PR DESCRIPTION
This fix allows to use redefs for the options in the example code.