### PR TITLE
Add note about requirement for hiredis to be installed

### DIFF
--- a/building-from-source.rst
+++ b/building-from-source.rst
@@ -184,6 +184,7 @@ build time:
     * PF_RING (Linux only, see :ref:`pf-ring-config`)
     * krb5 libraries and headers
     * ipsumdump (for trace-summary; https://github.com/kohler/ipsumdump)
+    * hiredis (for the Redis storage backend)
 
 ZeroMQ (e.g., libzmq3-dev on Debian/Ubuntu or cppzmq-devel on Fedora) is a
 requirement for developers working on core Zeek as some of Zeek's central

--- a/frameworks/storage.rst
+++ b/frameworks/storage.rst
@@ -195,6 +195,9 @@ Notes for Built-in Backends
 Redis
 -----
 
+- The Redis backend requires the ``hiredis`` library to installed on the system in order
+  to build. At least version 1.1.0 (Released Nov 2022) is required.
+
 - Redis server version 6.2.0 or later (or a third-party server implementing the equivalent
   level of the Redis API) is required. This is due to some API features the backend uses
   not being implemented until that version.


### PR DESCRIPTION
@initconf mentioned that the Redis backend wasn't building on his FreeBSD 12 machine. Fbsd 12 only provides hiredis 1.0.2, which doesn't include the poll adapter. That adapter isn't available until hiredis 1.1.0.