### PR TITLE
Remove extra spaces between words

### DIFF
--- a/about.rst
+++ b/about.rst
@@ -104,7 +104,7 @@ in the form of files), and judge traffic, respectively.
 It’s critical to collect and analyze the four types of network security
 monitoring data. The question becomes one of determining the best way to
 accomplish this goal. Thankfully, Zeek as a NSM platform enables collection of
-at least two, and in some ways three, of these data forms, namely  transaction
+at least two, and in some ways three, of these data forms, namely transaction
 data, extracted content, and alert data.
 
 Zeek is best known for its transaction data. By default, when run and told to

--- a/frameworks/cluster.rst
+++ b/frameworks/cluster.rst
@@ -217,7 +217,7 @@ functions, data centrality complexities can be addressed efficiently. One must
 rely on clusterization techniques provided by Zeek scripting, the Broker API,
 and clusterization components.
 
-When clustering your scripts, the fundamental work  to move data or events in
+When clustering your scripts, the fundamental work to move data or events in
 the context of a cluster falls primarily on few high level abstractions of
 communication patterns:
 
@@ -405,7 +405,7 @@ hashing key.
 The following example illustrates this issue. Assume that we are counting the
 number of scanner IPs from each ``/24`` subnet. If the key were the source IP,
 then depending on the hashing, different IP addresses from the same ``/24``
-might end up on  different proxies for the aggregation function. In this case
+might end up on different proxies for the aggregation function. In this case
 one might instead want to use a more inclusive hashing key, such as the subnet
 (``/24``) itself.  To illustrate the issue, in the notice log below, you see
 that 3 scanners each from ``52.100.165.0/24`` went to ``proxy-1`` and

--- a/frameworks/file-analysis.rst
+++ b/frameworks/file-analysis.rst
@@ -132,7 +132,7 @@ Generic analyzer registration
 The framework provides mechanisms for automatically attaching analyzers to
 files. For example, the :zeek:see:`Files::register_for_mime_types` function
 ensures that Zeek automatically attaches a given analyzer to all files of a
-given MIME type. For fully customized  auto-attachment logic take a look at
+given MIME type. For fully customized auto-attachment logic take a look at
 :zeek:see:`Files::register_analyzer_add_callback`, and refer to
 :doc:`base/frameworks/files/main.zeek </scripts/base/frameworks/files/main.zeek>`
 for additional APIs and data structures.

--- a/frameworks/input.rst
+++ b/frameworks/input.rst
@@ -431,7 +431,7 @@ input framework.
 The Binary Reader
 -----------------
 
-This  reader, selected via :zeek:see:`Input::READER_BINARY`, is intended for
+This reader, selected via :zeek:see:`Input::READER_BINARY`, is intended for
 use with file analysis input streams to ingest file content (and is the default
 type of reader for those streams).
 

--- a/logs/quic.rst
+++ b/logs/quic.rst
@@ -74,7 +74,7 @@ An example of a :file:`quic.log`.
       from the server of the new connection
 
     + A TLS ServerHello response from the server (s) - the
-      selection  of a cipher suite from the options provided by the
+      selection of a cipher suite from the options provided by the
       client
 
     + A handshake packet from the client (H)

--- a/script-reference/operators.rst
+++ b/script-reference/operators.rst
@@ -324,7 +324,7 @@ or user-defined).
   * - Type cast
     - ``v as t``
     - Cast value ``v`` into type ``t``. Evaluates to the value as cast to the
-      specified type.  If this is not a  supported cast, then a runtime error
+      specified type.  If this is not a supported cast, then a runtime error
       is triggered.
 
   * - Check if a cast is supported

--- a/script-reference/types.rst
+++ b/script-reference/types.rst
@@ -42,7 +42,7 @@ The Zeek scripting language supports the following built-in types:
     - File type (only for writing)
 
   * - :zeek:type:`opaque`
-    - Opaque type (for  some built-in  functions)
+    - Opaque type (for some built-in functions)
 
   * - :zeek:type:`any`
     - Any type (for functions or containers)
@@ -853,7 +853,7 @@ will infer ``int``.
 
 For signed-integer arithmetic involving ``int`` types that cause overflows
 (results that exceed the numeric limits of representable values in either
-direction), Zeek's behavior is generally undefined  and one should not rely on
+direction), Zeek's behavior is generally undefined and one should not rely on
 any observed behavior being consistent across compilers, platforms, time, etc.
 The reason for this is that the C++ standard also deems this as undefined
 behavior and Zeek does not currently attempt to detect such overflows within
@@ -1149,7 +1149,7 @@ Zeek supports the following pre-defined character classes:
 
   * - ``[:print:]``
     - ``[^[:cntrl:]]``
-    - Printable characters: those with  graphic representation, plus the space character.
+    - Printable characters: those with graphic representation, plus the space character.
 
   * - ``[:punct:]``
     -


### PR DESCRIPTION
This is a massive nit, but I noticed while reviewing https://github.com/zeek/zeek-docs/pull/328 that there were places with two spaces between words in a sentence. This removes the rest of those. Sphinx apparently takes care of them while building the docs for the website so they don't show there already.

There's a lot of them left that are inconsistencies with functions in `:zeek:see` annotations. I left those alone.